### PR TITLE
Add Flux GOVERNANCE doc

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -101,17 +101,17 @@ Oversight Committee members are publicly listed in the `@fluxcd/oversight-commit
 - Whether or not wider input is required, the Flux community believes that the best decisions are reached through Consensus <https://en.wikipedia.org/wiki/Consensus_decision-making>.
 - Most decisions start by seeking Lazy Consensus <https://communitymgt.wikia.com/wiki/Lazy_consensus>.
 - If an objection is raised through the Lazy Consensus process, Deciders work together to seek an agreeable solution.
-- If Consensus can not be reached, but a decision must be made, the next step is try to attempt to agree that a Vote should be called.
+- If Consensus can not be reached, but a decision must be made, the next step is try to attempt to agree that a vote should be called.
   This is important, as it gives dissenting views a chance to request more information or raise further points.
-  If Deciders are the Oversight Committee, part of that responsibility is the final point of escalation, so agreeing to a Vote is assumed if timeline doesn't allow the consensus process to continue.
-- If Deciders are Repository Maintainers, and they can't agree on calling a Vote, they may escalate to the Oversight Committee.
+  If Deciders are the Oversight Committee, part of that responsibility is the final point of escalation, so agreeing to a vote is assumed if timeline doesn't allow the consensus process to continue.
+- If Deciders are Repository Maintainers, and they can't agree on calling a vote, they may escalate to the Oversight Committee.
   This should only be done at this stage if:
   1. An unmovable deadline is threatened by continuing the Consensus process; or
-  2. A Decider feels there is unreasonable blocking of both reaching Consensus and agreeing to a Vote.
+  2. A Decider feels there is unreasonable blocking of both reaching Consensus and agreeing to a vote.
       This should be rare, due to the social cost of discontinuing the Consensus process for this reason.
       Most decisions should wait for the above process to take its course.
-- If Deciders agree to a Vote, the default is a Simple Majority Vote.
-- However, there are cases that require a stringer vote, specified below:
+- If Deciders agree to a vote, the default is a Simple Majority.
+- However, there are cases that require stronger voting – Supermajority or Unanimity – specified below:
 
 ### Simple Majority Decisions
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -163,7 +163,7 @@ If unclear which repository to create the issue in, default to the community rep
 ## Decision Making
 
 - Teams oversee activities appropriate to their defined scope and responsibilities.
-- Decisions that affect only one team are made informally by its maintainers.
+- Decisions that affect only one team are made informally by its members.
 - Decisions that affect multiple teams should go through the proposal process.
 - All proposals should be discussed publicly in the appropriate GitHub issue or pull request.
 - If a member of appropriate team feels feedback from members of the same or other teams is warranted they will @mention the users or teams to request feedback.
@@ -206,12 +206,16 @@ Once offboarding is complete and the issue is closed, they become a retired memb
 
 Org team membership changes have additional considerations:
 
-- Members of any other team are eligible to be nominated as an Org team member.
-- Org maintainers MUST remain current members of at least one other non-archived team.
+- There should be an odd number of Org team member seats, between 3 and 7.
+An odd number is to avoid a 50/50 decision split.
+A minimum of 3 is to prevent a single decision point.
+The current maximum is a guess to keep decision making efficient, and is subject to change.
+- Members of any other team are eligible to be nominated to fill an open Org team member seat.
+- Org members MUST also remain current members of at least one other non-archived team.
 If that status changes, they will also loose Org team membership.
-- If an Org maintainer voluntarily steps down, in addition to the process above, within 7 calendar days the Flux dev list MUST be notified <https://lists.cncf.io/g/cncf-flux-community>.
-This gives contributors reasonable time to be made aware of the change.
-- When there is an opening for a new Org maintainer, any contributor to a repository in the `fluxcd` GitHub org may nominate a suitable existing member of another team as a replacement.
+- If an Org member voluntarily steps down, in addition to the process above, within 7 calendar days the Flux dev list MUST be notified <https://lists.cncf.io/g/cncf-flux-dev>.
+This gives contributors reasonable time to be made aware of the opening.
+- When there is an open Org team member seat, any contributor to a repository in the `fluxcd` GitHub org may nominate a suitable existing member of another team as a replacement.
   - The nomination period will be three weeks starting the day after an Org team member opening becomes available.
   - The nomination must be made as a reply to the notification topic in the Flux dev list.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -111,10 +111,14 @@ Scope and responsibilities:
 Scope and responsibilities:
 
 - shared Maintainers responsibilities, as well as:
-- technical oversight on the overall project
-- providing architectural guidance to Dev team members
-- making technical decisions that are applicable to multiple sub-projects
 - administering and creating source code repositories
+- technical oversight on the overall project
+- making technical decisions that are applicable to multiple sub-projects
+- providing architectural guidance to Dev team members on an individual sub-project
+- representing sub-project interests in Architecture team decisions
+
+Every sub-project should have at least one Architecture team member as a Maintainer.
+The involvement of this Maintainer may be passive, but carries being responsible for duties that come with the Architecture team membership, including being a representative for the sub-project.
 
 ### Dev team
 
@@ -123,8 +127,11 @@ Scope and responsibilities:
 Scope and responsibilities:
 
 - shared Maintainers responsibilities, as well as:
+- collaborating with Architecture team member(s) who co-maintain project software
 - technical decisions related to project software the member maintains
 - release management related to the project software the member maintains
+- issue management related to the project software the member maintains
+- keeping documentation updated related to the project software the member maintains
 
 ### Security team
 
@@ -219,6 +226,11 @@ Dev team membership changes have additional considerations:
 - To gain and/or maintain Dev team membership the member MUST be a stated maintainer in at least one technical sub-project.
 - Technical sub-project maintainership is stated in a `MAINTAINERS` file at the root of the source code repository.
 - Stated technical sub-project maintainership may be decided by a Simple Majority of existing members listed in the project's `MAINTAINERS` file.
+
+Architecture team membership changes have additional considerations:
+
+- When an Architecture member leaves the team, their stated maintainership of any technical sub-projects will no longer count toward the required minimum of one Architecture team member.
+If after leaving, there are no other Architecture team members on those sub-projects, the Architecture team is reponsible for deciding how to fulfill that minimum.
 
 Org team membership changes have additional considerations:
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,8 +4,6 @@
 
 This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defines the governance process for the Flux CNCF project and community.
 
-The `fluxcd` github org is home to the Teams and source repositories listed below.
-
 - [Values](#values)
   - [Code of Conduct](#code-of-conduct)
 - [Member Roles](#member-roles)
@@ -83,7 +81,7 @@ Teams are responsible for the overall organization, code development, community 
 
 The goal of governing by teams is to allow parts of the project to act independently as appropriate, enabling the project to grow horizontally while remaining well-maintained.
 
-Teams below are also mapped to github teams within the fluxcd github org.
+Teams below are also mapped to github teams within the `fluxcd` github org.
 Their members are mapped to github user accounts.
 
 ### Org team

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -207,7 +207,7 @@ Once offboarding is complete and the issue is closed, they become an emeritus me
 Org team membership changes have additional considerations:
 
 - Members of any other team are eligible to be nominated as an Org team member.
-- Org maintainers MUST remain current members of other non-archived teams.
+- Org maintainers MUST remain current members of at least one other non-archived team.
 If that status changes, they will also loose Org team membership.
 - If an Org maintainer voluntarily steps down, in addition to the process above, within 7 calendar days the Flux dev list MUST be notified <https://lists.cncf.io/g/cncf-flux-community>.
 This gives contributors reasonable time to be made aware of the change.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,6 +12,7 @@ This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defi
   - [Maintainers](#maintainers)
 - [Teams](#teams)
   - [Org team](#org-team)
+  - [Architecture team](#architecture-team)
   - [Dev team](#dev-team)
   - [Security team](#security-team)
   - [Community team](#community-team)
@@ -93,29 +94,37 @@ Scope and responsibilities:
 - shared Maintainers responsibilities, as well as:
 - overseeing the project health and growth
 - maintaining the brand, mission, vision, values, and scope of the overall project
-- changes to licencing and intellectual property
+- changes to licensing and intellectual property
 - administering access to all project assets
-- administering, creating, archiving, and deleting source code repositories
+- deleting source code repositories
 - handling code of conduct violations
 - managing financial decisions
 - defining the scope and responsibilities of all other teams
-- making descisions that affect multiple teams
+- making decisions that affect multiple teams
 - resolving escalated team decisions when the teams responsible are blocked
 - changes to governance (this document)
+
+### Architecture team
+
+@fluxcd/arch <https://github.com/orgs/fluxcd/teams/arch>
+
+Scope and responsibilities:
+
+- shared Maintainers responsibilities, as well as:
+- technical oversight on the overall project
+- providing architectural guidance to Dev team members
+- making technical decisions that are applicable to multiple sub-projects
+- administering and creating source code repositories
 
 ### Dev team
 
 @fluxcd/dev <https://github.com/orgs/fluxcd/teams/dev>
 
-Note: Dev team members are scoped to one or more source code repositories, where they will be listed in a MAINTAINERS file in the root of that repo.
-How current Dev team members are allocated to which git repos may be decided by a Simple Majority of existing members listed in a git repo's MAINTAINERS file.
-In future, if more useful than relying on MAINTAINERS files, this team may explicitly split into separate dev-related teams, each scoped to one or more git repos.
-
 Scope and responsibilities:
 
 - shared Maintainers responsibilities, as well as:
-- all technical decisions related to project software, according to member's scoped git repos
-- release management, according to member's scoped git repos
+- technical decisions related to project software the member maintains
+- release management related to the project software the member maintains
 
 ### Security team
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -115,7 +115,7 @@ Oversight Committee members are publicly listed in the `@fluxcd/oversight-commit
 
 ### Simple Majority Changes
 
-- Maintainers: Election of new git project Maintainers by current Maintainers.
+- Maintainers: Election of new Maintainers by current git repository Maintainers.
 - Oversight Committee: Licensing and intellectual property changes.
 - Oversight Committee: Using Flux/CNCF money for anything CNCF deems "not cheap and easy".
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -213,7 +213,7 @@ A minimum of 3 is to prevent a single decision point.
 The current maximum is a guess to keep decision making efficient, and is subject to change.
 - Members of any other team are eligible to be nominated to fill an open Org team member seat.
 - Org members MUST also remain current members of at least one other non-archived team.
-If that status changes, they will also loose Org team membership.
+If that status changes, they will also lose Org team membership.
 - If an Org member voluntarily steps down, in addition to the process above, within 7 calendar days the Flux dev list MUST be notified <https://lists.cncf.io/g/cncf-flux-dev>.
 This gives contributors reasonable time to be made aware of the opening.
 - When there is an open Org team member seat, any contributor to a repository in the `fluxcd` GitHub org may nominate a suitable existing member of another team as a replacement.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -11,8 +11,10 @@ This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defi
   - [Contributors](#contributors)
   - [Maintainers](#maintainers)
   - [Oversight Committee](#oversight-committee)
-- [Proposal Process](#proposal-process)
 - [Decision Making](#decision-making)
+  - [Deciders](#deciders)
+  - [Kinds of Decisions](#kinds-of-decisions)
+- [Proposal Process](#proposal-process)
 - [Voting](#voting)
   - [Simple Majority Changes](#simple-majority-changes)
   - [Supermajority Changes](#supermajority-changes)
@@ -86,6 +88,18 @@ The aspiration is no one company or organization should have oversight of the ov
 
 Oversight Committee members are publicly listed in the `@fluxcd/oversight-committee` <https://github.com/orgs/fluxcd/teams/oversight-committee> GitHub team.
 
+## Decision Making
+
+### Deciders
+
+- Decisions that affect only one git repository are decided by its Maintainers.
+- Decisions that are outside the scope of a single git repository are decided by the Oversight Committee.
+
+### Kinds of Decisions
+
+- Most decisions do not require wider input, and may be made informally by the appropriate Deciders.
+- Decisions that warrant wider input should go through the Proposal Process.
+
 ## Proposal Process
 
 - Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with Maintainers, other contributors, and end users.
@@ -94,11 +108,6 @@ Oversight Committee members are publicly listed in the `@fluxcd/oversight-commit
   Note that Flux v2 uses GitHub discussions for proposals in the `fluxcd/toolkit` git repository <https://github.com/fluxcd/toolkit/discussions?discussions_q=category%3AProposals>.
 - Non-code changes should be proposed as GitHub issues.
   If unclear which git repository to create the issue in, default to the community repository <https://github.com/fluxcd/community>.
-
-## Decision Making
-
-- Decisions that affect only one git repository may be made informally by its Maintainers.
-- Decisions that affect multiple repositories, or otherwise warrant wider input, should go through the proposal process.
 - All proposals should be discussed publicly in an appropriate GitHub issue or pull request.
 - If a Maintainer of an affected git repository feels feedback from specific people is warranted they will @mention those users or teams to request feedback.
 - Proposals may also be added to the Flux Dev weekly meetings agenda, as a good avenue for making progress on a decision <https://lists.cncf.io/g/cncf-flux-dev/calendar>.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -146,9 +146,6 @@ If a vote is called, the following decisison require Unanimity <https://en.wikip
 - All proposals should be discussed publicly in an appropriate GitHub issue or pull request.
 - If a Maintainer of an affected git repository feels feedback from specific people is warranted they will @mention those users or teams to request feedback.
 - Proposals may also be added to the Flux Dev weekly meetings agenda, as a good avenue for making progress on a decision <https://lists.cncf.io/g/cncf-flux-dev/calendar>.
-- If there are objections and no consensus can be found, a vote may be called by a Maintainer.
-- When a vote is called, Maintainers will cast their yes/no vote on that GitHub issue or pull request, and after a suitable period of time, the outcome will be noted there.
-- If a proposal cannot be resolved by the affected git repository Maintainers, the decision may be escalated to the Oversight Committee.
 
 ## Licenses and Copyright
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -214,6 +214,12 @@ Once offboarding is complete and the issue is closed, they become a retired memb
 - When a team has no members the Org team become responsible for it and may either archive the team or find new members.
 - When a team is archived, its members become retired members of that team.
 
+Dev team membership changes have additional considerations:
+
+- To gain and/or maintain Dev team membership the member MUST be a stated maintainer in at least one technical sub-project.
+- Technical sub-project maintainership is stated in a `MAINTAINERS` file at the root of the source code repository.
+- Stated technical sub-project maintainership may be decided by a Simple Majority of existing members listed in the project's `MAINTAINERS` file.
+
 Org team membership changes have additional considerations:
 
 - There should be an odd number of Org team member seats, between 3 and 7.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -199,10 +199,10 @@ They do not change the intention or meaning of anything in this document.
 If they are unresponsive for > 3 months they will be automatically removed unless a supermajority of the other members of that team agrees to extend the period.
 - A member may voluntarily step down from a team by following the proposal process in the community repo.
 These proposals are automatically accepted.
-Once offboarding is complete and the issue is closed, they become an emeritus member of that team.
+Once offboarding is complete and the issue is closed, they become a retired member of that team.
 - New members may be added to a team by a supermajority vote by the existing members of that team.
 - When a team has no members the Org team become responsible for it and may either archive the team or find new members.
-- When a team is archived, its members become emeritus members of that team.
+- When a team is archived, its members become retired members of that team.
 
 Org team membership changes have additional considerations:
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -84,7 +84,7 @@ Ultimately the committee - after consulting with the collective of Maintainers a
 This committee will initially be comprised of Flux Maintainers who have steered the project prior to this initial Governance document.
 The aspiration is no one company or organization should have oversight of the overall project, however that is not yet realistic at this stage. The goal is to broaden maintainership to include a wider range of organizations during CNCF incubation.
 
-Oversight Committee members are publicly listed the `@fluxcd/oversight-committee` <https://github.com/orgs/fluxcd/teams/oversight-committee> GitHub team.
+Oversight Committee members are publicly listed in the `@fluxcd/oversight-committee` <https://github.com/orgs/fluxcd/teams/oversight-committee> GitHub team.
 
 ## Proposal Process
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -206,7 +206,7 @@ Once offboarding is complete and the issue is closed, they become an emeritus me
 
 Org team membership changes have additional considerations:
 
-- Members of any other team are eligible to be nominiated as an Org team member.
+- Members of any other team are eligible to be nominated as an Org team member.
 - Org maintainers MUST remain current members of other non-archived teams.
 If that status changes, they will also loose Org team membership.
 - If an Org maintainer volunteraily steps down, in addition to the process above, within 7 calendar days the Flux dev list MUST be notified <https://lists.cncf.io/g/cncf-flux-community>.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -38,7 +38,7 @@ If no conclusion can be reached in meditation, such issues can be escalated to t
 
 ## Roles in the Flux Community
 
-The Flux community is comprised of the following roles:
+The Flux community comprises the following roles:
 
 ### Users
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -90,11 +90,12 @@ Their members are mapped to GitHub user accounts.
 
 Scope and responsibilities:
 
-- shared Maintainers responsibilies, as well as
+- shared Maintainers responsibilies, as well as:
 - overseeing the project health and growth
 - maintaining the brand, mission, vision, values, and scope of the overall project
 - changes to licencing and intellectual property
 - administering access to all project assets
+- administering, creating, archiving, and deleting source code repositories
 - handling code of conduct violations
 - managing financial decisions
 - defining the scope and responsibilities of all other teams
@@ -106,15 +107,15 @@ Scope and responsibilities:
 
 @fluxcd/dev <https://github.com/orgs/fluxcd/teams/dev>
 
+Note: Dev team members are scoped to one or more source code repositories, where they will be listed in a MAINTAINERS file in the root of that repo.
+How current Dev team members are allocated to which git repos may be decided by a Simple Majority of existing members listed in a git repo's MAINTAINERS file.
+In future, if more useful than relying on MAINTAINERS files, this team may explicitly split into separate dev-related teams, each scoped to one or more git repos.
+
 Scope and responsibilities:
 
-- shared Maintainers responsibilies, as well as
-- all technical decisions related to project software
-- administering, creating, archiving, and deleting source code repositories
-- release management
-
-In future, the scope and responsibilities of this team may be split into separate dev-related teams.
-But even if so, due to Flux componentized architecture, there should be no assumption of a 1:1 relationship between a source repository and a team.
+- shared Maintainers responsibilies, as well as:
+- all technical decisions related to project software, according to member's scoped git repos
+- release management, according to member's scoped git repos
 
 ### Security team
 
@@ -122,7 +123,7 @@ But even if so, due to Flux componentized architecture, there should be no assum
 
 Scope and responsibilities:
 
-- shared Maintainers responsibilies, as well as
+- shared Maintainers responsibilies, as well as:
 - point of contact for reporting security vulnerabilities
 - responding to and investigating security reports
 - patching and releasing security fixes

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -81,8 +81,8 @@ Teams are responsible for the overall organization, code development, community 
 
 The goal of governing by teams is to allow parts of the project to act independently as appropriate, enabling the project to grow horizontally while remaining well-maintained.
 
-Teams below are also mapped to github teams within the `fluxcd` github org.
-Their members are mapped to github user accounts.
+Teams below are also mapped to GitHub teams within the `fluxcd` GitHub org.
+Their members are mapped to GitHub user accounts.
 
 ### Org team
 
@@ -154,10 +154,10 @@ Anyone may email this team with community-related questions <https://lists.cncf.
 ## Proposal Process
 
 - Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with maintainers of the appropriate team, other contributors, and end users.
-Pull requests should only be merged after receiving github approval from at least one other member of the appropriate team.
+Pull requests should only be merged after receiving GitHub approval from at least one other member of the appropriate team.
 Voting is not required for most code changes.
-Note that Flux v2 uses github discussions for proposals in the `fluxcd/toolkit` repo <https://github.com/fluxcd/toolkit/discussions?discussions_q=category%3AProposals>.
-- Non-code changes should be proposed as github issues.
+Note that Flux v2 uses GitHub discussions for proposals in the `fluxcd/toolkit` repo <https://github.com/fluxcd/toolkit/discussions?discussions_q=category%3AProposals>.
+- Non-code changes should be proposed as GitHub issues.
 If unclear which repository to create the issue in, default to the community repo <https://github.com/fluxcd/community>.
 
 ## Decision Making
@@ -165,7 +165,7 @@ If unclear which repository to create the issue in, default to the community rep
 - Teams oversee activities appropriate to their defined scope and responsibilities.
 - Decisions that affect only one team are made informally by its maintainers.
 - Decisions that affect multiple teams should go through the proposal process.
-- All proposals should be discussed publicly in the appropriate github issue or pull request.
+- All proposals should be discussed publicly in the appropriate GitHub issue or pull request.
 - If a member of appropriate team feels feedback from members of the same or other teams is warranted they will @mention the users or teams to request feedback.
 - Proposals may also be added to the Flux Dev weekly meetings agenda, as a good avenue for making progress on a decision <https://lists.cncf.io/g/cncf-flux-dev/calendar>.
 - If there are objections and no consensus can be found, a vote may be called by a team member.
@@ -181,8 +181,8 @@ These are defined below.
 
 ### Simple Majority Changes
 
-- Org team: Licensing and intellectual property changes
-- Org team: Using Flux/CNCF money for anything CNCF deems "not cheap and easy"
+- Org team: Licensing and intellectual property changes.
+- Org team: Using Flux/CNCF money for anything CNCF deems "not cheap and easy".
 
 ### Supermajority Changes
 
@@ -206,16 +206,16 @@ Once offboarding is complete and the issue is closed, they become an emeritus me
 
 Org team membership changes have additional considerations:
 
-- Members of any other team are eligible to be nominiated as an Org team member
+- Members of any other team are eligible to be nominiated as an Org team member.
 - Org maintainers MUST remain current members of other non-archived teams.
 If that status changes, they will also loose Org team membership.
 - If an Org maintainer volunteraily steps down, in addition to the process above, within 7 calendar days the Flux dev list MUST be notified <https://lists.cncf.io/g/cncf-flux-community>.
 This gives contributors reasonable time to be made aware of the change.
-- When there is an opening for a new Org maintainer, any contributor to a repository in the `fluxcd` github org may nominate a suitable existing member of another team as a replacement.
+- When there is an opening for a new Org maintainer, any contributor to a repository in the `fluxcd` GitHub org may nominate a suitable existing member of another team as a replacement.
   - The nomination period will be three weeks starting the day after an Org team member opening becomes available.
   - The nomination must be made as a reply to the notification topic in the Flux dev list.
 
 ## Licenses
 
-- Apache 2.0 is required for all source code repositories
-- Developer Certificate of Origin (DCO) commit signoff is required for all new code contributions
+- Apache 2.0 is required for all source code repositories.
+- Developer Certificate of Origin (DCO) commit signoff is required for all new code contributions.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -230,7 +230,7 @@ Dev team membership changes have additional considerations:
 Architecture team membership changes have additional considerations:
 
 - When an Architecture member leaves the team, their stated maintainership of any technical sub-projects will no longer count toward the required minimum of one Architecture team member.
-  If after leaving, there are no other Architecture team members on those sub-projects, the Architecture team is reponsible for deciding how to fulfill that minimum.
+  If after leaving, there are no other Architecture team members on those sub-projects, the Architecture team is responsible for deciding how to fulfill that minimum.
 
 Org team membership changes have additional considerations:
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,23 +6,17 @@ This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defi
 
 - [Values](#values)
   - [Code of Conduct](#code-of-conduct)
-- [Member Roles](#member-roles)
+- [Roles in the Flux Community](#roles-in-the-flux-community)
   - [Users](#users)
   - [Contributors](#contributors)
   - [Maintainers](#maintainers)
-- [Teams](#teams)
-  - [Org team](#org-team)
-  - [Architecture team](#architecture-team)
-  - [Dev team](#dev-team)
-  - [Security team](#security-team)
-  - [Community team](#community-team)
+  - [Oversight Committee](#oversight-committee)
 - [Proposal Process](#proposal-process)
 - [Decision Making](#decision-making)
 - [Voting](#voting)
   - [Simple Majority Changes](#simple-majority-changes)
   - [Supermajority Changes](#supermajority-changes)
-  - [Membership Changes](#membership-changes)
-- [Licenses](#licenses)
+- [Licenses and Copyright](#licenses-and-copyright)
 
 ## Values
 
@@ -33,221 +27,114 @@ Anyone may contribute, and contributions are available to all users according to
 Flux strives for transparency in all discussions, announcements, disclosures and decision making.
 - **Unbiased:**
 Flux strives to operate independently of specific partisan interests, and for decision making to fairly balance the wider community interests of its end users and contributors.
-In future, the aspiration is no one company or organization should employ a Simple Majority of the Org team members, however that is not yet realistic at this stage.
-The goal is to broaden membership of the Teams defined below to include a wider range of organizations during CNCF incubation.
 
 ### Code of Conduct
 
 The Flux community adheres to the CNCF Code of Conduct <https://github.com/cncf/foundation/blob/master/code-of-conduct.md>.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a _Flux_ project maintainer.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a _Flux_ Oversight Committee member.
 
-If the possible violation is against one of the Flux maintainers that member will be recused from voting on the issue.
-Such issues must be escalated to the CNCF mediator, Mishi Choudhary <mishi@linux.com>, in which case CNCF may choose to intervene.
+If no conclusion can be reached in meditation, such issues can be escalated to the CNCF mediator, Mishi Choudhary <mishi@linux.com>, in which case CNCF may choose to intervene.
 
-## Member Roles
+## Roles in the Flux Community
 
-The Flux community is comprised of the following member roles:
+The Flux community is comprised of the following roles:
 
 ### Users
 
-Flux end users are the most important members of the community, without whom the project would have no purpose. Users are anyone who has a need for the project.
+Flux end users are the most important aspect of the community, without whom the project would have no purpose. Users are anyone who has a need for the project.
 Apart from following the Code of Conduct, there are no special requirements.
-As users continue to engage and become more involved with the Flux community, they may find themselves becoming contributors.
 
 ### Contributors
 
 Flux welcomes all kinds of contributions, including code, issues, documentation, external tools, advocacy and community work.
-Contributors are accepted based on the merit of their contributions.
-Contributions help Maintainers ensure that the project continues to satisfy end user needs.
-Teams defined below may have different contribution processes and requirements for the various areas of Flux appropriate to their team.
+As a contributor we want to invite you to join the discussions in a variety of forums laid out in <https://github.com/fluxcd/community>.
 
 ### Maintainers
 
-Maintainers are elected Contributors who serve on one or more Teams.
-For the election process, see Membership Changes below.
+Maintainers are elected Contributors who showed significant and sustained contributions in a git repository.
+Current Maintainers are listed in a `MAINTAINERS` file at the root of the git repository.
 
 Maintainers are expected to:
 
-- enable and promote Flux community Values
-- engage with end Users through appropriate communication channels appropriate to their teams
-- serve as a point of conflict resolution between Contributors to the Flux area appropriate to their teams
-- maintain open collaboration within and across teams
-- additional responsibilities are defined per team below
+- Enable and promote Flux community values
+- Engage with end Users through appropriate communication channels
+- Serve as a point of conflict resolution between Contributors to their git repository
+- Maintain open collaboration within and across teams
+- Ask for help when unsure and step down considerately
 
-## Teams
+Maintainers will be invited to the `@fluxcd/maintainers` <https://github.com/orgs/fluxcd/teams/maintainers> team, and are members of this team for as long as they are involved with the project.
 
-The Flux project is governed by Maintainer teams, each with defined scope and responsibilities.
-Teams are responsible for the overall organization, code development, community management, and security.
+### Oversight Committee
 
-The goal of governing by teams is to allow parts of the project to act independently as appropriate, enabling the project to grow horizontally while remaining well-maintained.
+This committee is responsible for the overall project, and anything not easily managed by the Maintainers of each git repository. Including:
 
-Teams below are also mapped to GitHub teams within the `fluxcd` GitHub org.
-Their members are mapped to GitHub user accounts.
+- Overseeing the project health and growth
+- Maintaining the brand, mission, vision, values, and scope of the overall project
+- Changes to licensing and intellectual property
+- Administering access to all project assets
+- Administering git repositories as needed
+- Handling Code of Conduct violations
+- Managing financial decisions
+- Defining the scope of each git repository
+- Resolving escalated decisions when the git repository Maintainers responsible are blocked
 
-### Org team
+Ultimately the committee - after consulting with the collective of Maintainers and their community - drive the direction, values and governance of the overall project.
 
-@fluxcd/org <https://github.com/orgs/fluxcd/teams/org>
+This committee will initially be comprised of Flux Maintainers who have steered the project prior to this initial Governance document.
+The aspiration is no one company or organization should have oversight of the overall project, however that is not yet realistic at this stage. The goal is to broaden maintainership to include a wider range of organizations during CNCF incubation.
 
-Scope and responsibilities:
-
-- shared Maintainers responsibilities, as well as:
-- overseeing the project health and growth
-- maintaining the brand, mission, vision, values, and scope of the overall project
-- changes to licensing and intellectual property
-- administering access to all project assets
-- deleting source code repositories
-- handling code of conduct violations
-- managing financial decisions
-- defining the scope and responsibilities of all other teams
-- making decisions that affect multiple teams
-- resolving escalated team decisions when the teams responsible are blocked
-- changes to governance (this document)
-
-### Architecture team
-
-@fluxcd/arch <https://github.com/orgs/fluxcd/teams/arch>
-
-Scope and responsibilities:
-
-- shared Maintainers responsibilities, as well as:
-- administering and creating source code repositories
-- technical oversight on the overall project
-- making technical decisions that are applicable to multiple sub-projects
-- providing architectural guidance to Dev team members on an individual sub-project
-- representing sub-project interests in Architecture team decisions
-
-Every sub-project should have at least one Architecture team member as a Maintainer.
-The involvement of this Maintainer may be passive, but carries being responsible for duties that come with the Architecture team membership, including being a representative for the sub-project.
-
-### Dev team
-
-@fluxcd/dev <https://github.com/orgs/fluxcd/teams/dev>
-
-Scope and responsibilities:
-
-- shared Maintainers responsibilities, as well as:
-- collaborating with Architecture team member(s) who co-maintain project software
-- technical decisions related to project software the member maintains
-- release management related to the project software the member maintains
-- issue management related to the project software the member maintains
-- keeping documentation updated related to the project software the member maintains
-
-### Security team
-
-@fluxcd/security <https://github.com/orgs/fluxcd/teams/security>
-
-Scope and responsibilities:
-
-- shared Maintainers responsibilities, as well as:
-- point of contact for reporting security vulnerabilities
-- responding to and investigating security reports
-- patching and releasing security fixes
-- publishing the vulnerability disclosure once a mitigation strategy is available
-- documenting overall project security best practices
-
-Anyone may email this team privately to safely raise possible security vulnerabilities <https://lists.cncf.io/g/cncf-flux-security>.
-
-### Community team
-
-@fluxcd/community <https://github.com/orgs/fluxcd/teams/community>
-
-Scope and responsibilities:
-
-- shared Maintainers responsibilities, as well as
-- listening to the community
-- escalating community issues to appropriate teams
-- planning and executing community events
-- marketing related tasks required by the project
-- managing partner and ecosystem development
-- managing social media accounts (example: Twitter)
-- managing project mailing lists
-- managing project calendar events
-- managing project blog posts
-- managing the project website
-
-Anyone may email this team with community-related questions <https://lists.cncf.io/g/cncf-flux-community>.
+Oversight Committee members are publicly listed the `@fluxcd/oversight-committee` <https://github.com/orgs/fluxcd/teams/oversight-committee> GitHub team.
 
 ## Proposal Process
 
-- Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with maintainers of the appropriate team, other contributors, and end users.
-  Pull requests should only be merged after receiving GitHub approval from at least one other member of the appropriate team.
+- Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with Maintainers, other contributors, and end users.
+  Pull requests should only be merged after receiving GitHub approval from at least one other Maintainer.
   Voting is not required for most code changes.
-  Note that Flux v2 uses GitHub discussions for proposals in the `fluxcd/toolkit` repo <https://github.com/fluxcd/toolkit/discussions?discussions_q=category%3AProposals>.
+  Note that Flux v2 uses GitHub discussions for proposals in the `fluxcd/toolkit` git repository <https://github.com/fluxcd/toolkit/discussions?discussions_q=category%3AProposals>.
 - Non-code changes should be proposed as GitHub issues.
-  If unclear which repository to create the issue in, default to the community repo <https://github.com/fluxcd/community>.
+  If unclear which git repository to create the issue in, default to the community repository <https://github.com/fluxcd/community>.
 
 ## Decision Making
 
-- Teams oversee activities appropriate to their defined scope and responsibilities.
-- Decisions that affect only one team are made informally by its members.
-- Decisions that affect multiple teams should go through the proposal process.
-- All proposals should be discussed publicly in the appropriate GitHub issue or pull request.
-- If a member of appropriate team feels feedback from members of the same or other teams is warranted they will @mention the users or teams to request feedback.
+- Decisions that affect only one git repository may be made informally by its Maintainers.
+- Decisions that affect multiple repositories, or otherwise warrant wider input, should go through the proposal process.
+- All proposals should be discussed publicly in an appropriate GitHub issue or pull request.
+- If a Maintainer of an affected git repository feels feedback from specific people is warranted they will @mention those users or teams to request feedback.
 - Proposals may also be added to the Flux Dev weekly meetings agenda, as a good avenue for making progress on a decision <https://lists.cncf.io/g/cncf-flux-dev/calendar>.
-- If there are objections and no consensus can be found, a vote may be called by a team member.
-- When a vote is called, members of the appropriate team team will cast their yes/no vote on that github issue or pull request, and after a suitable period of time, the votes will be tallied and the outcome noted.
-- If a proposal cannot be resolved by the affected teams, the decision may be escalated to the Org team.
+- If there are objections and no consensus can be found, a vote may be called by a Maintainer.
+- When a vote is called, Maintainers will cast their yes/no vote on that GitHub issue or pull request, and after a suitable period of time, the outcome will be noted there.
+- If a proposal cannot be resolved by the affected git repository Maintainers, the decision may be escalated to the Oversight Committee.
 
 ## Voting
 
-- Most team decisions are made by lazy consensus <https://communitymgt.wikia.com/wiki/Lazy_consensus>.
-- In these cases, if no consensus can be reached, the matter may be resolved by Simple Majority Vote <https://en.wikipedia.org/wiki/Majority> by the appropriate team.
-- However there are cases that always require a Simple Majority or Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority> by the appropriate team.
-  These are defined below.
+- Most Maintainer decisions are made by lazy consensus <https://communitymgt.wikia.com/wiki/Lazy_consensus>.
+- If no consensus can be reached, the matter may be resolved by Simple Majority Vote <https://en.wikipedia.org/wiki/Majority>.
+- However there are cases that always require a Simple Majority or Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority>.
+  These are defined below:
 
 ### Simple Majority Changes
 
-- Org team: Licensing and intellectual property changes.
-- Org team: Using Flux/CNCF money for anything CNCF deems "not cheap and easy".
+- Maintainers: Election of new git project Maintainers by current Maintainers.
+- Oversight Committee: Licensing and intellectual property changes.
+- Oversight Committee: Using Flux/CNCF money for anything CNCF deems "not cheap and easy".
 
 ### Supermajority Changes
 
-- Org team: Enforcing a Code of Conduct violation.
-- Org team: Removing a member from a team for any reason other than inactivity.
-- Org team: Material changes to the Governance document.
-  - Editorial changes to governance may be made by Org team lazy consensus, unless challenged.
+- Oversight Committee: Enforcing a Code of Conduct violation.
+- Oversight Committee: Removing a Maintainer for any reason other than inactivity.
+- Oversight Committee: Material changes to the Governance document.
+  - Editorial changes to governance may be made by lazy consensus, unless challenged.
     These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.
     They do not change the intention or meaning of anything in this document.
 
-### Membership Changes
+## Licenses and Copyright
 
-- All team members MUST remain active contributors.
-  If they are unresponsive for > 3 months they will be automatically removed unless a supermajority of the other members of that team agrees to extend the period.
-- A member may voluntarily step down from a team by following the proposal process in the community repo.
-  These proposals are automatically accepted.
-  Once offboarding is complete and the issue is closed, they become a retired member of that team.
-- New members may be added to a team by a supermajority vote by the existing members of that team.
-- When a team has no members the Org team become responsible for it and may either archive the team or find new members.
-- When a team is archived, its members become retired members of that team.
-
-Dev team membership changes have additional considerations:
-
-- To gain and/or maintain Dev team membership the member MUST be a stated maintainer in at least one technical sub-project.
-- Technical sub-project maintainership is stated in a `MAINTAINERS` file at the root of the source code repository.
-- Stated technical sub-project maintainership may be decided by a Simple Majority of existing members listed in the project's `MAINTAINERS` file.
-
-Architecture team membership changes have additional considerations:
-
-- When an Architecture member leaves the team, their stated maintainership of any technical sub-projects will no longer count toward the required minimum of one Architecture team member.
-  If after leaving, there are no other Architecture team members on those sub-projects, the Architecture team is responsible for deciding how to fulfill that minimum.
-
-Org team membership changes have additional considerations:
-
-- There should be an odd number of Org team member seats, between 3 and 7.
-  An odd number is to avoid a 50/50 decision split.
-  A minimum of 3 is to prevent a single decision point.
-  The current maximum is a guess to keep decision making efficient, and is subject to change.
-- Members of any other team are eligible to be nominated to fill an open Org team member seat.
-- Org members MUST also remain current members of at least one other non-archived team.
-  If that status changes, they will also lose Org team membership.
-- If an Org member voluntarily steps down, in addition to the process above, within 7 calendar days the Flux dev list MUST be notified <https://lists.cncf.io/g/cncf-flux-dev>.
-  This gives contributors reasonable time to be made aware of the opening.
-- When there is an open Org team member seat, any contributor to a repository in the `fluxcd` GitHub org may nominate a suitable existing member of another team as a replacement.
-  - The nomination period will be three weeks starting the day after an Org team member opening becomes available.
-  - The nomination must be made as a reply to the notification topic in the Flux dev list.
-
-## Licenses
-
-- Apache 2.0 is required for all source code repositories.
+- Apache 2.0 is required for all git repositories.
 - Developer Certificate of Origin (DCO) commit signoff is required for all new code contributions.
+
+Links to relevant CNCF documentation:
+
+- <https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy>
+- <https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist>
+- <https://github.com/cncf/foundation/blob/master/copyright-notices.md#copyright-notices>

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,7 +2,7 @@
 <!-- omit in toc -->
 # Flux Governance
 
-This document <github.com/fluxcd/community/blob/main/GOVERNANCE.md> defines the governance process for the Flux CNCF project and community.
+This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defines the governance process for the Flux CNCF project and community.
 
 The `fluxcd` github org is home to the Teams and source repositories listed below.
 
@@ -39,7 +39,7 @@ The goal is to broaden membership of the Teams defined below to include a wider 
 
 ### Code of Conduct
 
-The Flux community adheres to the CNCF Code of Conduct <github.com/cncf/foundation/blob/master/code-of-conduct.md>.
+The Flux community adheres to the CNCF Code of Conduct <https://github.com/cncf/foundation/blob/master/code-of-conduct.md>.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a _Flux_ project maintainer.
 
@@ -88,7 +88,7 @@ Their members are mapped to github user accounts.
 
 ### Org team
 
-@fluxcd/org <github.com/orgs/fluxcd/teams/org>
+@fluxcd/org <https://github.com/orgs/fluxcd/teams/org>
 
 Scope and responsibilities:
 
@@ -106,7 +106,7 @@ Scope and responsibilities:
 
 ### Dev team
 
-@fluxcd/dev <github.com/orgs/fluxcd/teams/dev>
+@fluxcd/dev <https://github.com/orgs/fluxcd/teams/dev>
 
 Scope and responsibilities:
 
@@ -120,7 +120,7 @@ But even if so, due to Flux componentized architecture, there should be no assum
 
 ### Security team
 
-@fluxcd/security <github.com/orgs/fluxcd/teams/security>
+@fluxcd/security <https://github.com/orgs/fluxcd/teams/security>
 
 Scope and responsibilities:
 
@@ -131,11 +131,11 @@ Scope and responsibilities:
 - publishing the vulnerability disclosure once a mitigation strategy is available
 - documenting overall project security best practices
 
-Anyone may email this team privately to safely raise possible security vulnerabilities <lists.cncf.io/g/cncf-flux-community>.
+Anyone may email this team privately to safely raise possible security vulnerabilities <https://lists.cncf.io/g/cncf-flux-community>.
 
 ### Community team
 
-@fluxcd/community <github.com/orgs/fluxcd/teams/community>
+@fluxcd/community <https://github.com/orgs/fluxcd/teams/community>
 
 Scope and responsibilities:
 
@@ -151,16 +151,16 @@ Scope and responsibilities:
 - managing project blog posts
 - managing the project website
 
-Anyone may email this team with community-related questions <lists.cncf.io/g/cncf-flux-community>.
+Anyone may email this team with community-related questions <https://lists.cncf.io/g/cncf-flux-community>.
 
 ## Proposal Process
 
 - Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with maintainers of the appropriate team, other contributors, and end users.
 Pull requests should only be merged after receiving github approval from at least one other member of the appropriate team.
 Voting is not required for most code changes.
-Note that Flux v2 uses github discussions for proposals in the `fluxcd/toolkit` repo <github.com/fluxcd/toolkit/discussions?discussions_q=category%3AProposals>.
+Note that Flux v2 uses github discussions for proposals in the `fluxcd/toolkit` repo <https://github.com/fluxcd/toolkit/discussions?discussions_q=category%3AProposals>.
 - Non-code changes should be proposed as github issues.
-If unclear which repository to create the issue in, default to the community repo <github.com/fluxcd/community>.
+If unclear which repository to create the issue in, default to the community repo <https://github.com/fluxcd/community>.
 
 ## Decision Making
 
@@ -169,16 +169,16 @@ If unclear which repository to create the issue in, default to the community rep
 - Decisions that affect multiple teams should go through the proposal process.
 - All proposals should be discussed publicly in the appropriate github issue or pull request.
 - If a member of appropriate team feels feedback from members of the same or other teams is warranted they will @mention the users or teams to request feedback.
-- Proposals may also be added to the Flux Dev weekly meetings agenda, as a good avenue for making progress on a decision <lists.cncf.io/g/cncf-flux-dev/calendar>.
+- Proposals may also be added to the Flux Dev weekly meetings agenda, as a good avenue for making progress on a decision <https://lists.cncf.io/g/cncf-flux-dev/calendar>.
 - If there are objections and no consensus can be found, a vote may be called by a team member.
 - When a vote is called, members of the appropriate team team will cast their yes/no vote on that github issue or pull request, and after a suitable period of time, the votes will be tallied and the outcome noted.
 - If a proposal cannot be resolved by the affected teams, the decision may be escalated to the Org team.
 
 ## Voting
 
-- Most team decisions are made by lazy consensus <communitymgt.wikia.com/wiki/Lazy_consensus>.
-- In these cases, if no consensus can be reached, the matter may be resolved by Simple Majority Vote <en.wikipedia.org/wiki/Majority> by the appropriate team.
-- However there are cases that always require a Simple Majority or Supermajority Vote <en.wikipedia.org/wiki/Supermajority> by the appropriate team.
+- Most team decisions are made by lazy consensus <https://communitymgt.wikia.com/wiki/Lazy_consensus>.
+- In these cases, if no consensus can be reached, the matter may be resolved by Simple Majority Vote <https://en.wikipedia.org/wiki/Majority> by the appropriate team.
+- However there are cases that always require a Simple Majority or Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority> by the appropriate team.
 These are defined below.
 
 ### Simple Majority Changes
@@ -211,7 +211,7 @@ Org team membership changes have additional considerations:
 - Members of any other team are eligible to be nominiated as an Org team member
 - Org maintainers MUST remain current members of other non-archived teams.
 If that status changes, they will also loose Org team membership.
-- If an Org maintainer volunteraily steps down, in addition to the process above, within 7 calendar days the Flux dev list MUST be notified <lists.cncf.io/g/cncf-flux-community>.
+- If an Org maintainer volunteraily steps down, in addition to the process above, within 7 calendar days the Flux dev list MUST be notified <https://lists.cncf.io/g/cncf-flux-community>.
 This gives contributors reasonable time to be made aware of the change.
 - When there is an opening for a new Org maintainer, any contributor to a repository in the `fluxcd` github org may nominate a suitable existing member of another team as a replacement.
   - The nomination period will be three weeks starting the day after an Org team member opening becomes available.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -79,7 +79,7 @@ This committee is responsible for the overall project, and anything not easily m
 - Handling Code of Conduct violations
 - Managing financial decisions
 - Defining the scope of each git repository
-- Resolving escalated decisions when the git repository Maintainers responsible are blocked
+- Resolving escalated decisions when Maintainers responsible are blocked
 
 Ultimately the committee - after consulting with the collective of Maintainers and their community - drive the direction, values and governance of the overall project.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -171,11 +171,11 @@ Anyone may email this team with community-related questions <https://lists.cncf.
 ## Proposal Process
 
 - Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with maintainers of the appropriate team, other contributors, and end users.
-Pull requests should only be merged after receiving GitHub approval from at least one other member of the appropriate team.
-Voting is not required for most code changes.
-Note that Flux v2 uses GitHub discussions for proposals in the `fluxcd/toolkit` repo <https://github.com/fluxcd/toolkit/discussions?discussions_q=category%3AProposals>.
+  Pull requests should only be merged after receiving GitHub approval from at least one other member of the appropriate team.
+  Voting is not required for most code changes.
+  Note that Flux v2 uses GitHub discussions for proposals in the `fluxcd/toolkit` repo <https://github.com/fluxcd/toolkit/discussions?discussions_q=category%3AProposals>.
 - Non-code changes should be proposed as GitHub issues.
-If unclear which repository to create the issue in, default to the community repo <https://github.com/fluxcd/community>.
+  If unclear which repository to create the issue in, default to the community repo <https://github.com/fluxcd/community>.
 
 ## Decision Making
 
@@ -194,7 +194,7 @@ If unclear which repository to create the issue in, default to the community rep
 - Most team decisions are made by lazy consensus <https://communitymgt.wikia.com/wiki/Lazy_consensus>.
 - In these cases, if no consensus can be reached, the matter may be resolved by Simple Majority Vote <https://en.wikipedia.org/wiki/Majority> by the appropriate team.
 - However there are cases that always require a Simple Majority or Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority> by the appropriate team.
-These are defined below.
+  These are defined below.
 
 ### Simple Majority Changes
 
@@ -207,16 +207,16 @@ These are defined below.
 - Org team: Removing a member from a team for any reason other than inactivity.
 - Org team: Material changes to the Governance document.
   - Editorial changes to governance may be made by Org team lazy consensus, unless challenged.
-These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.
-They do not change the intention or meaning of anything in this document.
+    These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.
+    They do not change the intention or meaning of anything in this document.
 
 ### Membership Changes
 
 - All team members MUST remain active contributors.
-If they are unresponsive for > 3 months they will be automatically removed unless a supermajority of the other members of that team agrees to extend the period.
+  If they are unresponsive for > 3 months they will be automatically removed unless a supermajority of the other members of that team agrees to extend the period.
 - A member may voluntarily step down from a team by following the proposal process in the community repo.
-These proposals are automatically accepted.
-Once offboarding is complete and the issue is closed, they become a retired member of that team.
+  These proposals are automatically accepted.
+  Once offboarding is complete and the issue is closed, they become a retired member of that team.
 - New members may be added to a team by a supermajority vote by the existing members of that team.
 - When a team has no members the Org team become responsible for it and may either archive the team or find new members.
 - When a team is archived, its members become retired members of that team.
@@ -230,19 +230,19 @@ Dev team membership changes have additional considerations:
 Architecture team membership changes have additional considerations:
 
 - When an Architecture member leaves the team, their stated maintainership of any technical sub-projects will no longer count toward the required minimum of one Architecture team member.
-If after leaving, there are no other Architecture team members on those sub-projects, the Architecture team is reponsible for deciding how to fulfill that minimum.
+  If after leaving, there are no other Architecture team members on those sub-projects, the Architecture team is reponsible for deciding how to fulfill that minimum.
 
 Org team membership changes have additional considerations:
 
 - There should be an odd number of Org team member seats, between 3 and 7.
-An odd number is to avoid a 50/50 decision split.
-A minimum of 3 is to prevent a single decision point.
-The current maximum is a guess to keep decision making efficient, and is subject to change.
+  An odd number is to avoid a 50/50 decision split.
+  A minimum of 3 is to prevent a single decision point.
+  The current maximum is a guess to keep decision making efficient, and is subject to change.
 - Members of any other team are eligible to be nominated to fill an open Org team member seat.
 - Org members MUST also remain current members of at least one other non-archived team.
-If that status changes, they will also lose Org team membership.
+  If that status changes, they will also lose Org team membership.
 - If an Org member voluntarily steps down, in addition to the process above, within 7 calendar days the Flux dev list MUST be notified <https://lists.cncf.io/g/cncf-flux-dev>.
-This gives contributors reasonable time to be made aware of the opening.
+  This gives contributors reasonable time to be made aware of the opening.
 - When there is an open Org team member seat, any contributor to a repository in the `fluxcd` GitHub org may nominate a suitable existing member of another team as a replacement.
   - The nomination period will be three weeks starting the day after an Org team member opening becomes available.
   - The nomination must be made as a reply to the notification topic in the Flux dev list.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -60,7 +60,7 @@ Maintainers are expected to:
 - Enable and promote Flux community values
 - Engage with end Users through appropriate communication channels
 - Serve as a point of conflict resolution between Contributors to their git repository
-- Maintain open collaboration within and across teams
+- Maintain open collaboration with Contributors and other Maintainers
 - Ask for help when unsure and step down considerately
 
 Maintainers will be invited to the `@fluxcd/maintainers` <https://github.com/orgs/fluxcd/teams/maintainers> team, and are members of this team for as long as they are involved with the project.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -157,7 +157,7 @@ Scope and responsibilities:
 - shared Maintainers responsibilities, as well as
 - listening to the community
 - escalating community issues to appropriate teams
-- planning and executing community events (example: GitOps Days)
+- planning and executing community events
 - marketing related tasks required by the project
 - managing partner and ecosystem development
 - managing social media accounts (example: Twitter)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -77,7 +77,7 @@ Maintainers are expected to:
 
 ## Teams
 
-The Flux project is governed by Maintainer teams, each with defined scope and resonsibilities.
+The Flux project is governed by Maintainer teams, each with defined scope and responsibilities.
 Teams are responsible for the overall organization, code development, community management, and security.
 
 The goal of governing by teams is to allow parts of the project to act independently as appropriate, enabling the project to grow horizontally while remaining well-maintained.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -130,7 +130,7 @@ Scope and responsibilities:
 - publishing the vulnerability disclosure once a mitigation strategy is available
 - documenting overall project security best practices
 
-Anyone may email this team privately to safely raise possible security vulnerabilities <https://lists.cncf.io/g/cncf-flux-community>.
+Anyone may email this team privately to safely raise possible security vulnerabilities <https://lists.cncf.io/g/cncf-flux-security>.
 
 ### Community team
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -139,7 +139,7 @@ If a vote is called, the following decisison require Unanimity <https://en.wikip
 ## Proposal Process
 
 - Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with Maintainers, other contributors, and end users.
-  Pull requests should only be merged after receiving GitHub approval from at least one other Maintainer.
+  Pull requests should only be merged after receiving GitHub approval from at least one Maintainer who is not the pull request author.
   Note that Flux v2 uses GitHub discussions for proposals in the `fluxcd/toolkit` git repository <https://github.com/fluxcd/toolkit/discussions?discussions_q=category%3AProposals>.
 - Non-code changes should be proposed as GitHub issues.
   If unclear which git repository to create the issue in, default to the community repository <https://github.com/fluxcd/community>.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -90,7 +90,7 @@ Their members are mapped to GitHub user accounts.
 
 Scope and responsibilities:
 
-- shared Maintainers responsibilies, as well as:
+- shared Maintainers responsibilities, as well as:
 - overseeing the project health and growth
 - maintaining the brand, mission, vision, values, and scope of the overall project
 - changes to licencing and intellectual property
@@ -113,7 +113,7 @@ In future, if more useful than relying on MAINTAINERS files, this team may expli
 
 Scope and responsibilities:
 
-- shared Maintainers responsibilies, as well as:
+- shared Maintainers responsibilities, as well as:
 - all technical decisions related to project software, according to member's scoped git repos
 - release management, according to member's scoped git repos
 
@@ -123,7 +123,7 @@ Scope and responsibilities:
 
 Scope and responsibilities:
 
-- shared Maintainers responsibilies, as well as:
+- shared Maintainers responsibilities, as well as:
 - point of contact for reporting security vulnerabilities
 - responding to and investigating security reports
 - patching and releasing security fixes

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -13,11 +13,11 @@ This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defi
   - [Oversight Committee](#oversight-committee)
 - [Decision Making](#decision-making)
   - [Deciders](#deciders)
-  - [Kinds of Decisions](#kinds-of-decisions)
+  - [Decision Guidelines](#decision-guidelines)
+  - [Simple Majority Decisions](#simple-majority-decisions)
+  - [Supermajority Decisions](#supermajority-decisions)
+  - [Unanimity Decisions](#unanimity-decisions)
 - [Proposal Process](#proposal-process)
-- [Voting](#voting)
-  - [Simple Majority Changes](#simple-majority-changes)
-  - [Supermajority Changes](#supermajority-changes)
 - [Licenses and Copyright](#licenses-and-copyright)
 
 ## Values
@@ -92,19 +92,54 @@ Oversight Committee members are publicly listed in the `@fluxcd/oversight-commit
 
 ### Deciders
 
-- Decisions that affect only one git repository are decided by its Maintainers.
-- Decisions that are outside the scope of a single git repository are decided by the Oversight Committee.
+- Repository Maintainers: Decisions that affect only one git repository.
+- Oversight Committee: Decisions that are outside the scope of a single git repository.
 
-### Kinds of Decisions
+### Decision Guidelines
 
-- Most decisions do not require wider input, and may be made informally by the appropriate Deciders.
-- Decisions that warrant wider input should go through the Proposal Process.
+- Decisions that warrant wider input should be made public by using the below guidelines in combination with the Proposal Process below.
+- Whether or not wider input is required, the Flux community believes that the best decisions are reached through Consensus <https://en.wikipedia.org/wiki/Consensus_decision-making>.
+- Most decisions start by seeking Lazy Consensus <https://communitymgt.wikia.com/wiki/Lazy_consensus>.
+- If an objection is raised through the Lazy Consensus process, Deciders work together to seek an agreeable solution.
+- If Consensus can not be reached, but a decision must be made, the next step is try to attempt to agree that a Vote should be called.
+  This is important, as it gives dissenting views a chance to request more information or raise further points.
+  If Deciders are the Oversight Committee, part of that responsibility is the final point of escalation, so agreeing to a Vote is assumed if timeline doesn't allow the consensus process to continue.
+- If Deciders are Repository Maintainers, and they can't agree on calling a Vote, they may escalate to the Oversight Committee.
+  This should only be done at this stage if:
+  1. An unmovable deadline is threatened by continuing the Consensus process; or
+  2. A Decider feels there is unreasonable blocking of both reaching Consensus and agreeing to a Vote.
+      This should be rare, due to the social cost of discontinuing the Consensus process for this reason.
+      Most decisions should wait for the above process to take its course.
+- If Deciders agree to a Vote, the default is a Simple Majority Vote.
+- However, there are cases that require a stringer vote, specified below:
+
+### Simple Majority Decisions
+
+If a vote is called, the default is a Simple Majority Vote <https://en.wikipedia.org/wiki/Majority>.
+
+### Supermajority Decisions
+
+If a vote is called, the following decisions require a Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority>.
+
+- Oversight Committee: Enforcing a Code of Conduct violation by a community member.
+- Oversight Committee: Licensing and intellectual property changes.
+- Oversight Committee: Material changes to the Governance document.
+  - Note: editorial changes to governance may be made by lazy consensus, unless challenged.
+    These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.
+    They do not change the intention or meaning of anything in this document.
+
+### Unanimity Decisions
+
+If a vote is called, the following decisison require Unanimity <https://en.wikipedia.org/wiki/Unanimity>.
+
+- Repository Maintainers: Electing new Maintainers of the same repository.
+- Oversight Committee: Electing new Committee members.
+- Oversight Committee: Removing a Repository Maintainer or Committee member for any reason other than inactivity.
 
 ## Proposal Process
 
 - Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with Maintainers, other contributors, and end users.
   Pull requests should only be merged after receiving GitHub approval from at least one other Maintainer.
-  Voting is not required for most code changes.
   Note that Flux v2 uses GitHub discussions for proposals in the `fluxcd/toolkit` git repository <https://github.com/fluxcd/toolkit/discussions?discussions_q=category%3AProposals>.
 - Non-code changes should be proposed as GitHub issues.
   If unclear which git repository to create the issue in, default to the community repository <https://github.com/fluxcd/community>.
@@ -114,28 +149,6 @@ Oversight Committee members are publicly listed in the `@fluxcd/oversight-commit
 - If there are objections and no consensus can be found, a vote may be called by a Maintainer.
 - When a vote is called, Maintainers will cast their yes/no vote on that GitHub issue or pull request, and after a suitable period of time, the outcome will be noted there.
 - If a proposal cannot be resolved by the affected git repository Maintainers, the decision may be escalated to the Oversight Committee.
-
-## Voting
-
-- Most Maintainer decisions are made by lazy consensus <https://communitymgt.wikia.com/wiki/Lazy_consensus>.
-- If no consensus can be reached, the matter may be resolved by Simple Majority Vote <https://en.wikipedia.org/wiki/Majority>.
-- However there are cases that always require a Simple Majority or Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority>.
-  These are defined below:
-
-### Simple Majority Changes
-
-- Maintainers: Election of new Maintainers by current git repository Maintainers.
-- Oversight Committee: Licensing and intellectual property changes.
-- Oversight Committee: Using Flux/CNCF money for anything CNCF deems "not cheap and easy".
-
-### Supermajority Changes
-
-- Oversight Committee: Enforcing a Code of Conduct violation.
-- Oversight Committee: Removing a Maintainer for any reason other than inactivity.
-- Oversight Committee: Material changes to the Governance document.
-  - Editorial changes to governance may be made by lazy consensus, unless challenged.
-    These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.
-    They do not change the intention or meaning of anything in this document.
 
 ## Licenses and Copyright
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,223 @@
+<!-- see https://github.com/yzhang-gh/vscode-markdown/blob/master/README.md#table-of-contents -->
+<!-- omit in toc -->
+# Flux Governance
+
+This document <github.com/fluxcd/community/blob/main/GOVERNANCE.md> defines the governance process for the Flux CNCF project and community.
+
+The `fluxcd` github org is home to the Teams and source repositories listed below.
+
+- [Values](#values)
+  - [Code of Conduct](#code-of-conduct)
+- [Member Roles](#member-roles)
+  - [Users](#users)
+  - [Contributors](#contributors)
+  - [Maintainers](#maintainers)
+- [Teams](#teams)
+  - [Org team](#org-team)
+  - [Dev team](#dev-team)
+  - [Security team](#security-team)
+  - [Community team](#community-team)
+- [Proposal Process](#proposal-process)
+- [Decision Making](#decision-making)
+- [Voting](#voting)
+  - [Simple Majority Changes](#simple-majority-changes)
+  - [Supermajority Changes](#supermajority-changes)
+  - [Membership Changes](#membership-changes)
+- [Licenses](#licenses)
+
+## Values
+
+- **Open:**
+The Flux community strives to be open, accessible and welcoming to everyone.
+Anyone may contribute, and contributions are available to all users according to open source values and licenses.
+- **Transparent:**
+Flux strives for transparency in all discussions, announcements, disclosures and decision making.
+- **Unbiased:**
+Flux strives to operate independently of specific partisan interests, and for decision making to fairly balance the wider community interests of its end users and contributors.
+In future, the aspiration is no one company or organization should employ a Simple Majority of the Org team members, however that is not yet realistic at this stage.
+The goal is to broaden membership of the Teams defined below to include a wider range of organizations during CNCF incubation.
+
+### Code of Conduct
+
+The Flux community adheres to the CNCF Code of Conduct <github.com/cncf/foundation/blob/master/code-of-conduct.md>.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a _Flux_ project maintainer.
+
+If the possible violation is against one of the Flux maintainers that member will be recused from voting on the issue.
+Such issues must be escalated to the CNCF mediator, Mishi Choudhary <mishi@linux.com>, in which case CNCF may choose to intervene.
+
+## Member Roles
+
+The Flux community is comprised of the following member roles:
+
+### Users
+
+Flux end users are the most important members of the community, without whom the project would have no purpose. Users are anyone who has a need for the project.
+Apart from following the Code of Conduct, there are no special requirements.
+As users continue to engage and become more involved with the Flux community, they may find themselves becoming contributors.
+
+### Contributors
+
+Flux welcomes all kinds of contributions, including code, issues, documentation, external tools, advocacy and community work.
+Contributors are accepted based on the merit of their contributions.
+Contributions help Maintainers ensure that the project continues to satisfy end user needs.
+Teams defined below may have different contribution processes and requirements for the various areas of Flux appropriate to their team.
+
+### Maintainers
+
+Maintainers are elected Contributors who serve on one or more Teams.
+For the election process, see Membership Changes below.
+
+Maintainers are expected to:
+
+- enable and promote Flux community Values
+- engage with end Users through appropriate communication channels appropriate to their teams
+- serve as a point of conflict resolution between Contributors to the Flux area appropriate to their teams
+- maintain open collaboration within and across teams
+- additional responsibilites are defined per team below
+
+## Teams
+
+The Flux project is governed by Maintainer teams, each with defined scope and resonsibilities.
+Teams are responsible for the overall organization, code development, community management, and security.
+
+The goal of governing by teams is to allow parts of the project to act independently as appropriate, enabling the project to grow horizontally while remaining well-maintained.
+
+Teams below are also mapped to github teams within the fluxcd github org.
+Their members are mapped to github user accounts.
+
+### Org team
+
+@fluxcd/org <github.com/orgs/fluxcd/teams/org>
+
+Scope and responsibilities:
+
+- shared Maintainers responsibilies, as well as
+- overseeing the project health and growth
+- maintaining the brand, mission, vision, values, and scope of the overall project
+- changes to licencing and intellectual property
+- administering access to all project assets
+- handling code of conduct violations
+- managing financial decisions
+- defining the scope and responsibilities of all other teams
+- making descisions that affect multiple teams
+- resolving escalated team decisions when the teams responsible are blocked
+- changes to governance (this document)
+
+### Dev team
+
+@fluxcd/dev <github.com/orgs/fluxcd/teams/dev>
+
+Scope and responsibilities:
+
+- shared Maintainers responsibilies, as well as
+- all technical decisions related to project software
+- administering, creating, archiving, and deleting source code repositories
+- release management
+
+In future, the scope and responsibilities of this team may be split into separate dev-related teams.
+But even if so, due to Flux componentized architecture, there should be no assumption of a 1:1 relationship between a source repository and a team.
+
+### Security team
+
+@fluxcd/security <github.com/orgs/fluxcd/teams/security>
+
+Scope and responsibilities:
+
+- shared Maintainers responsibilies, as well as
+- point of contact for reporting security vulnerabilities
+- responding to and investigating security reports
+- patching and releasing security fixes
+- publishing the vulnerability disclosure once a mitigation strategy is available
+- documenting overall project security best practices
+
+Anyone may email this team privately to safely raise possible security vulnerabilities <lists.cncf.io/g/cncf-flux-community>.
+
+### Community team
+
+@fluxcd/community <github.com/orgs/fluxcd/teams/community>
+
+Scope and responsibilities:
+
+- shared Maintainers responsibilies, as well as
+- listening to the community
+- escalating community issues to appropriate teams
+- planning and executing community events (example: GitOps Days)
+- marketing related tasks required by the project
+- managing partner and ecosystem development
+- managing social media accounts (example: Twitter)
+- managing project mailing lists
+- managing project calendar events
+- managing project blog posts
+- managing the project website
+
+Anyone may email this team with community-related questions <lists.cncf.io/g/cncf-flux-community>.
+
+## Proposal Process
+
+- Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with maintainers of the appropriate team, other contributors, and end users.
+Pull requests should only be merged after receiving github approval from at least one other member of the appropriate team.
+Voting is not required for most code changes.
+Note that Flux v2 uses github discussions for proposals in the `fluxcd/toolkit` repo <github.com/fluxcd/toolkit/discussions?discussions_q=category%3AProposals>.
+- Non-code changes should be proposed as github issues.
+If unclear which repository to create the issue in, default to the community repo <github.com/fluxcd/community>.
+
+## Decision Making
+
+- Teams oversee activities appropriate to their defined scope and responsibilities.
+- Decisions that affect only one team are made informally by its maintainers.
+- Decisions that affect multiple teams should go through the proposal process.
+- All proposals should be discussed publicly in the appropriate github issue or pull request.
+- If a member of appropriate team feels feedback from members of the same or other teams is warranted they will @mention the users or teams to request feedback.
+- Proposals may also be added to the Flux Dev weekly meetings agenda, as a good avenue for making progress on a decision <lists.cncf.io/g/cncf-flux-dev/calendar>.
+- If there are objections and no consensus can be found, a vote may be called by a team member.
+- When a vote is called, members of the appropriate team team will cast their yes/no vote on that github issue or pull request, and after a suitable period of time, the votes will be tallied and the outcome noted.
+- If a proposal cannot be resolved by the affected teams, the decision may be escalated to the Org team.
+
+## Voting
+
+- Most team decisions are made by lazy consensus <communitymgt.wikia.com/wiki/Lazy_consensus>.
+- In these cases, if no consensus can be reached, the matter may be resolved by Simple Majority Vote <en.wikipedia.org/wiki/Majority> by the appropriate team.
+- However there are cases that always require a Simple Majority or Supermajority Vote <en.wikipedia.org/wiki/Supermajority> by the appropriate team.
+These are defined below.
+
+### Simple Majority Changes
+
+- Org team: Licensing and intellectual property changes
+- Org team: Using Flux/CNCF money for anything CNCF deems "not cheap and easy"
+
+### Supermajority Changes
+
+- Org team: Enforcing a Code of Conduct violation.
+- Org team: Removing a member from a team for any reason other than inactivity.
+- Org team: Material changes to the Governance document.
+  - Editorial changes to governance may be made by Org team lazy consensus, unless challenged.
+These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.
+They do not change the intention or meaning of anything in this document.
+
+### Membership Changes
+
+- All team members MUST remain active contributors.
+If they are unresponsive for > 3 months they will be automatically removed unless a supermajority of the other members of that team agrees to extend the period.
+- A member may voluntarily step down from a team by following the proposal process in the community repo.
+These proposals are automatically accepted.
+Once offboarding is complete and the issue is closed, they become an emeritus member of that team.
+- New members may be added to a team by a supermajority vote by the existing members of that team.
+- When a team has no members the Org team become responsible for it and may either archive the team or find new members.
+- When a team is archived, its members become emeritus members of that team.
+
+Org team membership changes have additional considerations:
+
+- Members of any other team are eligible to be nominiated as an Org team member
+- Org maintainers MUST remain current members of other non-archived teams.
+If that status changes, they will also loose Org team membership.
+- If an Org maintainer volunteraily steps down, in addition to the process above, within 7 calendar days the Flux dev list MUST be notified <lists.cncf.io/g/cncf-flux-community>.
+This gives contributors reasonable time to be made aware of the change.
+- When there is an opening for a new Org maintainer, any contributor to a repository in the `fluxcd` github org may nominate a suitable existing member of another team as a replacement.
+  - The nomination period will be three weeks starting the day after an Org team member opening becomes available.
+  - The nomination must be made as a reply to the notification topic in the Flux dev list.
+
+## Licenses
+
+- Apache 2.0 is required for all source code repositories
+- Developer Certificate of Origin (DCO) commit signoff is required for all new code contributions

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -73,7 +73,7 @@ Maintainers are expected to:
 - engage with end Users through appropriate communication channels appropriate to their teams
 - serve as a point of conflict resolution between Contributors to the Flux area appropriate to their teams
 - maintain open collaboration within and across teams
-- additional responsibilites are defined per team below
+- additional responsibilities are defined per team below
 
 ## Teams
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -137,7 +137,7 @@ Anyone may email this team privately to safely raise possible security vulnerabi
 
 Scope and responsibilities:
 
-- shared Maintainers responsibilies, as well as
+- shared Maintainers responsibilities, as well as
 - listening to the community
 - escalating community issues to appropriate teams
 - planning and executing community events (example: GitOps Days)
@@ -209,7 +209,7 @@ Org team membership changes have additional considerations:
 - Members of any other team are eligible to be nominated as an Org team member.
 - Org maintainers MUST remain current members of other non-archived teams.
 If that status changes, they will also loose Org team membership.
-- If an Org maintainer volunteraily steps down, in addition to the process above, within 7 calendar days the Flux dev list MUST be notified <https://lists.cncf.io/g/cncf-flux-community>.
+- If an Org maintainer voluntarily steps down, in addition to the process above, within 7 calendar days the Flux dev list MUST be notified <https://lists.cncf.io/g/cncf-flux-community>.
 This gives contributors reasonable time to be made aware of the change.
 - When there is an opening for a new Org maintainer, any contributor to a repository in the `fluxcd` GitHub org may nominate a suitable existing member of another team as a replacement.
   - The nomination period will be three weeks starting the day after an Org team member opening becomes available.


### PR DESCRIPTION
Fixes #1 
Closes #15 

## Intro

This is an initial draft PR for community feedback. @dholbach was kind enough to do an initial quick scan at https://hackmd.io/sBKKaeTgRmO4JYziwq4teQ?both but now it's time to discuss. Please preview at https://github.com/scottrigby/flux-community/blob/governance/GOVERNANCE.md and see what you think 🙂

## Changes for Contributors

### DCO

As soon as this PR is merged, Developer Certificate of Origin (DCO) commit signoff will be required for all new code contributions in the `fluxcd` GitHub org repos.

Note either DCO or CLA is required for CNCF projects. I proposed DCO, as it's easier for end users, and built into git.

For those unfamiliar with DCO, see `git help commit`:

```
-s, --signoff
    Add Signed-off-by line by the committer at the end of the commit log
    message. The meaning of a signoff depends on the project, but it typically
    certifies that committer has the rights to submit this work under the same
    license and agrees to a Developer Certificate of Origin (see
    http://developercertificate.org/ for more information).
```

Your DCO signoff is drawn from your gitconfig's name and email. If you choose to manually add a signoff line, it must be properly formatted and must match your commit information. For example, if you use a GitHub [private email](https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address) (like `<username>@users.noreply.github.com`) you must make sure to set your gitconfig's email accordingly.

For those who wish to ensure this is always done in your CLI, consider implementing something like [this gist](https://gist.github.com/scottrigby/0c043c0bfbbdb5949e2d824fc3adeaa4). I have successfully used this for several years.

Whenever commit messages are added in the GitHub UI, consider using the [DCO GitHub UI](https://github.com/scottrigby/dco-gh-ui) browser plugin for Chrome or Firefox, which I also maintain, and is in use by a number of contributors to CNCF projects.

## Timeline

- One week for initial comments on this PR (Thurs 15 Oct)
- One week for final thoughts after all initial comments have been addressed (Thurs 22 Oct)
- **Update:** as of Friday 23 Oct there are still details being ironed out. Stay tuned ⏳ 

Readiness to merge the PR will be decided by Lazy consensus. At which point: 
- this GOVERNANCE doc PR will be committed
- we will email the flux-dev list letting contributors know about the DCO change above
- we will enable the DCO bot across all repos in the `fluxcd` GitHub org

We will also notify users and contributors of the above dates, in CNCF Slack #flux channels, and on the flux-dev mailing list.

## Additional Context

**Edit** I removed earlier additional context. I tried to take a less is more approach with the doc itself, since by definition it needs to stand on its own. If interested, see description history for this PR ⏳ 