### PR TITLE
add minimal Governance doc for Flux project

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,60 @@
+# Flux Governance
+
+This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defines the governance process for the Flux CNCF project and community.
+
+## Values
+
+- **Open:**
+The Flux community strives to be open, accessible and welcoming to everyone.
+Anyone may contribute, and contributions are available to all users according to open source values and licenses.
+- **Transparent:**
+Flux strives for transparency in all discussions, announcements, disclosures and decision making.
+- **Unbiased:**
+Flux strives to operate independently of specific partisan interests, and for decision making to fairly balance the wider community interests of its end users and contributors.
+
+### Code of Conduct
+
+The Flux community adheres to the CNCF Code of Conduct <https://github.com/cncf/foundation/blob/master/code-of-conduct.md>.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a _Flux_ project maintainer.
+
+If no conclusion can be reached in meditation, such issues can be escalated to the CNCF mediator, Mishi Choudhary <mishi@linux.com>, in which case CNCF may choose to intervene.
+
+## Roles in the Flux Community
+
+The Flux community is comprised of the following roles:
+
+### Users
+
+Flux end users are the most important aspect of the community, without whom the project would have no purpose. Users are anyone who has a need for the project.
+Apart from following the Code of Conduct, there are no special requirements.
+
+### Contributors
+
+Flux welcomes all kinds of contributions, including code, issues, documentation, external tools, advocacy and community work.
+As a contributor we want to invite you to join the discussions in a variety of fora laid out in <https://github.com/fluxcd/community>.
+
+### Maintainers
+
+Maintainers are elected Contributors who showed significant and sustained contributions in particular sub-project. A majority of positive votes of current maintainers is sufficient.
+
+Maintainers are expected to:
+
+- enable and promote Flux community Values
+- engage with end Users through appropriate communication channels appropriate to their teams
+- serve as a point of conflict resolution between Contributors to the Flux area appropriate to their teams
+- maintain open collaboration within and across teams
+- ask for help when unsure and step down considerately
+
+Ultimately the collective of maintainers - after consulting with their community - drive the direction, values and governance of the project.
+
+## Licenses and copyright
+
+- Apache 2.0 is required for all source code repositories.
+- Developer Certificate of Origin (DCO) commit signoff is required for all new code contributions.
+
+Links to relevant CNCF documentation:
+
+- <https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy>
+- <https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist>
+- <https://github.com/cncf/foundation/blob/master/copyright-notices.md#copyright-notices>


### PR DESCRIPTION
As discussed with @scottrigby, this is an alternate take on a Governance doc in #13. It's intentionally the bare-bones approach to help us figure out what the right balance of governance is now to get us started, as the discussion is a little stuck right now.