### PR TITLE
Refer to flux project/community, not "fluxcd" or "Flux CNCF"

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 ## Code of Conduct
 
-FluxCD community follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+The Flux community follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,7 +2,7 @@
 <!-- omit in toc -->
 # Flux Governance
 
-This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defines the governance process for the Flux CNCF project and community.
+This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defines the governance process for the Flux project and community.
 
 - [Values](#values)
   - [Code of Conduct](#code-of-conduct)


### PR DESCRIPTION
@hiddeco Thanks for noticing this in https://github.com/fluxcd/community/pull/20#discussion_r512777803 !

Spotted another mention of Flux that didn't roll off the tongue easily either ("Flux CNCF project").