### PR TITLE
Add SECURITY document

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,11 +14,11 @@ We're very thankful for – and if desired happy to credit – security researc
 
 ## Security Team
 
-Crrent Security Team members:
+Current Security Team members:
 
 | Name | GitHub | Key URL | Fingerprint |
 | -- | -- | -- | -- |
-| Scott Rigby | [@scottrigby](https://github.com/scottrigby) | <https://keybase.io/r6by/pgp_keys.asc> | 208D D36E D5BB 3745 A167  43A4 C7C6 FBB5 B91C 1155 |
+| Scott Rigby | [@scottrigby](https://github.com/scottrigby) | <https://keybase.io/r6by/pgp_keys.asc> | 208D D36E D5BB 3745 A167 43A4 C7C6 FBB5 B91C 1155 |
 | Hidde Beydals | [@hiddeco](https://github.com/hiddeco) | <https://keybase.io/hidde/pgp_keys.asc> | C910 7A9B 55A4 DD77 062B 9731 B6E3 6A6A C54A CD59 |
 
 ## Handling
@@ -35,4 +35,4 @@ Vulnerability disclosures are emailed to the Flux Dev mailing list <https://list
 Disclosures will contain an overview, details about the vulnerability, a fix that will typically be an update, and optionally a workaround if one is available.
 
 We prefer to fully disclose the vulnerability as soon as possible once a user mitigation is available.
-Disclosures will be published on the same day as a release fixing the vulnerability after the release is published.
+Disclosures will be published on the same day as a release fixing the vulnerability, after the release is published.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,10 @@
 # Flux Security
 
-This document <https://github.com/fluxcd/community/blob/main/SECURITY.md> defines security reporting, handling, and disclosure information for the Flux CNCF project and community.
+This document <https://github.com/fluxcd/community/blob/main/SECURITY.md> defines security reporting, handling, and disclosure information for the Flux project and community.
 
 ## Report a Vulnerability
 
-We're very thankful for – and if desired happy to credit – security researchers and users who report vulnerabilities to the Flux Community.
+We're very thankful for – and if desired happy to credit – security researchers and users who report vulnerabilities to the Flux community.
 
 - To make a report please email the private security list at <cncf-flux-security@lists.cncf.io> with the details.
   We ask that reporters act in good faith by not disclosing the issue to others.
@@ -23,7 +23,7 @@ Crrent Security Team members:
 
 ## Handling
 
-- All reports are thoroughly investigated by the Flux security team.
+- All reports are thoroughly investigated by the Security Team.
 - Any vulnerability information shared with the Security Team will not be shared with others unless it is necessary to fix the issue.
   Information is shared only on a need to know basis.
 - As the security issue moves through the identification and resolution process, the reporter will be notified.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,10 +16,10 @@ We're very thankful for – and if desired happy to credit – security researc
 
 Crrent Security Team members:
 
-| Name | Key URL | Fingerprint |
-| -- | -- | -- |
-| Scott Rigby [@scottrigby](https://github.com/scottrigby) | <https://keybase.io/r6by/pgp_keys.asc> | 208D D36E D5BB 3745 A167  43A4 C7C6 FBB5 B91C 1155 |
-| Hidde Beydals [@hiddeco](https://github.com/hiddeco) | PLACEHOLDER | PLACEHOLDER |
+| Name | GitHub | Key URL | Fingerprint |
+| -- | -- | -- | -- |
+| Scott Rigby | [@scottrigby](https://github.com/scottrigby) | <https://keybase.io/r6by/pgp_keys.asc> | 208D D36E D5BB 3745 A167  43A4 C7C6 FBB5 B91C 1155 |
+| Hidde Beydals | [@hiddeco](https://github.com/hiddeco) | <https://keybase.io/hidde/pgp_keys.asc> | C910 7A9B 55A4 DD77 062B 9731 B6E3 6A6A C54A CD59 |
 
 ## Handling
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Flux Security
+
+This document <https://github.com/fluxcd/community/blob/main/SECURITY.md> defines security reporting, handling, and disclosure information for the Flux CNCF project and community.
+
+## Report a Vulnerability
+
+We're very thankful for – and if desired happy to credit – security researchers and users who report vulnerabilities to the Flux Community.
+
+- To make a report please email the private security list at <cncf-flux-security@lists.cncf.io> with the details.
+  We ask that reporters act in good faith by not disclosing the issue to others.
+- You may, but are not required to, encrypt your email to this list using the PGP keys of Security Team members, listed below.
+- The Security Team will fix the issue as soon as possible and coordinate a release date with you.
+- You will be able to choose if you want public acknowledgement of your effort and how you would like to be credited.
+
+## Security Team
+
+Crrent Security Team members:
+
+| Name | Key URL | Fingerprint |
+| -- | -- | -- |
+| Scott Rigby [@scottrigby](https://github.com/scottrigby) | <https://keybase.io/r6by/pgp_keys.asc> | 208D D36E D5BB 3745 A167  43A4 C7C6 FBB5 B91C 1155 |
+| Hidde Beydals [@hiddeco](https://github.com/hiddeco) | PLACEHOLDER | PLACEHOLDER |
+
+## Handling
+
+- All reports are thoroughly investigated by the Flux security team.
+- Any vulnerability information shared with the Security Team will not be shared with others unless it is necessary to fix the issue.
+  Information is shared only on a need to know basis.
+- As the security issue moves through the identification and resolution process, the reporter will be notified.
+- Additional questions about the vulnerability may also be asked of the reporter.
+
+## Disclosures
+
+Vulnerability disclosures are emailed to the Flux Dev mailing list <https://lists.cncf.io/g/cncf-flux-dev> and announced publicly.
+Disclosures will contain an overview, details about the vulnerability, a fix that will typically be an update, and optionally a workaround if one is available.
+
+We prefer to fully disclose the vulnerability as soon as possible once a user mitigation is available.
+Disclosures will be published on the same day as a release fixing the vulnerability after the release is published.


### PR DESCRIPTION
Fixes #2 

@fluxcd/oversight-committee 

Initial draft of Flux security processes and info.

- Much of this drawn from https://kubernetes.io/docs/reference/issues-security/security/ and https://github.com/helm/community/blob/master/SECURITY.md. Simplified a bit. We can continue to provide further detail as needed.
- ~Temporary PLACEHOLDER for @hiddeco PGP keys.~
- We have a keybase team, which is a logical choice for trusting user account PGP keys
- Also are there other maintainers who would like to be initial security team members?