### PR TITLE
Update flux2 repository name

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -140,7 +140,7 @@ If a vote is called, the following decisison require Unanimity <https://en.wikip
 
 - Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with Maintainers, other contributors, and end users.
   Pull requests should only be merged after receiving GitHub approval from at least one Maintainer who is not the pull request author.
-  Note that Flux v2 uses GitHub discussions for proposals in the `fluxcd/toolkit` git repository <https://github.com/fluxcd/toolkit/discussions?discussions_q=category%3AProposals>.
+  Note that Flux v2 uses GitHub discussions for proposals in the `fluxcd/flux2` git repository <https://github.com/fluxcd/flux2/discussions?discussions_q=category%3AProposals>.
 - Non-code changes should be proposed as GitHub issues.
   If unclear which git repository to create the issue in, default to the community repository <https://github.com/fluxcd/community>.
 - All proposals should be discussed publicly in an appropriate GitHub issue or pull request.


### PR DESCRIPTION
Update GH Discussions repository link to `fluxcd/flux2`.