### PR TITLE
Expand, Modify community roles

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -20,30 +20,30 @@ This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defi
 
 - **Open:**
 The Flux community strives to be open, accessible and welcoming to everyone.
-Anyone may contribute, and contributions are available to all users according to open source values and licenses.
+Anyone may contribute, and contributions are available to all [Users][User] according to open source values and licenses.
 - **Transparent:**
 Flux strives for transparency in all discussions, announcements, disclosures and decision making.
 - **Unbiased:**
-Flux strives to operate independently of specific partisan interests, and for decision making to fairly balance the wider community interests of its end users and contributors.
+Flux strives to operate independently of specific partisan interests, and for decision making to fairly balance the wider community interests of its end [Users][User] and contributors.
 
 ### Code of Conduct
 
 The Flux community adheres to the CNCF Code of Conduct <https://github.com/cncf/foundation/blob/master/code-of-conduct.md>.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a _Flux_ Oversight Committee member.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a _Flux_ [Oversight Committee] member.
 
 If no conclusion can be reached in meditation, such issues can be escalated to the CNCF mediator, Mishi Choudhary <mishi@linux.com>, in which case CNCF may choose to intervene.
 
 ## Roles in the Flux Community
 
-See [community-roles.md](community-roles.md)
+See [community-roles.md]
 
 ## Decision Making
 
 ### Deciders
 
-- Repository Maintainers: Decisions that affect only one Git repository.
-- Oversight Committee: Decisions that are outside the scope of a single Git repository.
+- Repository [Maintainers]: Decisions that affect only one git repository.
+- [Oversight Committee]: Decisions that are outside the scope of a single git repository.
 
 ### Decision Guidelines
 
@@ -53,8 +53,8 @@ See [community-roles.md](community-roles.md)
 - If an objection is raised through the Lazy Consensus process, Deciders work together to seek an agreeable solution.
 - If Consensus can not be reached, but a decision must be made, the next step is try to attempt to agree that a vote should be called.
   This is important, as it gives dissenting views a chance to request more information or raise further points.
-  If Deciders are the Oversight Committee, part of that responsibility is the final point of escalation, so agreeing to a vote is assumed if timeline doesn't allow the consensus process to continue.
-- If Deciders are Repository Maintainers, and they can't agree on calling a vote, they may escalate to the Oversight Committee.
+  If Deciders are the [Oversight Committee], part of that responsibility is the final point of escalation, so agreeing to a vote is assumed if timeline doesn't allow the consensus process to continue.
+- If Deciders are Repository [Maintainers], and they can't agree on calling a vote, they may escalate to the [Oversight Committee].
   This should only be done at this stage if:
   1. An unmovable deadline is threatened by continuing the Consensus process; or
   2. A Decider feels there is unreasonable blocking of both reaching Consensus and agreeing to a vote.
@@ -71,9 +71,9 @@ If a vote is called, the default is a Simple Majority Vote <https://en.wikipedia
 
 If a vote is called, the following decisions require a Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority>.
 
-- Oversight Committee: Enforcing a Code of Conduct violation by a community member.
-- Oversight Committee: Licensing and intellectual property changes.
-- Oversight Committee: Material changes to the Governance document.
+- [Oversight Committee]: Enforcing a Code of Conduct violation by a community member.
+- [Oversight Committee]: Licensing and intellectual property changes.
+- [Oversight Committee]: Material changes to the Governance document.
   - Note: editorial changes to governance may be made by lazy consensus, unless challenged.
     These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.
     They do not change the intention or meaning of anything in this document.
@@ -82,19 +82,19 @@ If a vote is called, the following decisions require a Supermajority Vote <https
 
 If a vote is called, the following decisison require Unanimity <https://en.wikipedia.org/wiki/Unanimity>.
 
-- Repository Maintainers: Electing new Maintainers of the same repository.
-- Oversight Committee: Electing new Committee members.
-- Oversight Committee: Removing a Repository Maintainer or Committee member for any reason other than inactivity.
+- Repository [Maintainers]: Electing new Maintainers of the same repository.
+- [Oversight Committee]: Electing new Committee members.
+- [Oversight Committee]: Removing a Repository Maintainer or Committee member for any reason other than inactivity.
 
 ## Proposal Process
 
-- Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with Maintainers, other contributors, and end users.
+- Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with [Maintainers], other contributors, and end [Users][User].
   Pull requests should only be merged after receiving GitHub approval from at least one Maintainer who is not the pull request author.
   Note that Flux v2 uses GitHub discussions for proposals in the `fluxcd/flux2` Git repository <https://github.com/fluxcd/flux2/discussions?discussions_q=category%3AProposals>.
 - Non-code changes should be proposed as GitHub issues.
   If unclear which Git repository to create the issue in, default to the community repository <https://github.com/fluxcd/community>.
 - All proposals should be discussed publicly in an appropriate GitHub issue or pull request.
-- If a Maintainer of an affected Git repository feels feedback from specific people is warranted they will @mention those users or teams to request feedback.
+- If a Maintainer of an affected git repository feels feedback from specific people is warranted they will @mention those [Users] or teams to request feedback.
 - Proposals may also be added to the Flux Dev weekly meetings agenda, as a good avenue for making progress on a decision <https://lists.cncf.io/g/cncf-flux-dev/calendar>.
 
 ## Licenses and Copyright
@@ -107,3 +107,8 @@ Links to relevant CNCF documentation:
 - <https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy>
 - <https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist>
 - <https://github.com/cncf/foundation/blob/master/copyright-notices.md#copyright-notices>
+
+[User]: community-roles.md#user
+[Maintainer]: community-roles.md#maintainer
+[Oversight Committee]: community-roles.md#oversight-committee
+[community-roles.md]: community-roles.md

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -20,11 +20,11 @@ This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defi
 
 - **Open:**
 The Flux community strives to be open, accessible and welcoming to everyone.
-Anyone may contribute, and contributions are available to all [Users][User] according to open source values and licenses.
+Anyone may contribute, and contributions are available to all users according to open source values and licenses.
 - **Transparent:**
 Flux strives for transparency in all discussions, announcements, disclosures and decision making.
 - **Unbiased:**
-Flux strives to operate independently of specific partisan interests, and for decision making to fairly balance the wider community interests of its end [Users][User] and contributors.
+Flux strives to operate independently of specific partisan interests, and for decision making to fairly balance the wider community interests of its end users and contributors.
 
 ### Code of Conduct
 
@@ -42,7 +42,7 @@ See [community-roles.md]
 
 ### Deciders
 
-- Repository [Maintainers]: Decisions that affect only one git repository.
+- Repository [Maintainers][Maintainer]: Decisions that affect only one git repository.
 - [Oversight Committee]: Decisions that are outside the scope of a single git repository.
 
 ### Decision Guidelines
@@ -54,7 +54,7 @@ See [community-roles.md]
 - If Consensus can not be reached, but a decision must be made, the next step is try to attempt to agree that a vote should be called.
   This is important, as it gives dissenting views a chance to request more information or raise further points.
   If Deciders are the [Oversight Committee], part of that responsibility is the final point of escalation, so agreeing to a vote is assumed if timeline doesn't allow the consensus process to continue.
-- If Deciders are Repository [Maintainers], and they can't agree on calling a vote, they may escalate to the [Oversight Committee].
+- If Deciders are Repository [Maintainers][Maintainer], and they can't agree on calling a vote, they may escalate to the [Oversight Committee].
   This should only be done at this stage if:
   1. An unmovable deadline is threatened by continuing the Consensus process; or
   2. A Decider feels there is unreasonable blocking of both reaching Consensus and agreeing to a vote.
@@ -82,19 +82,19 @@ If a vote is called, the following decisions require a Supermajority Vote <https
 
 If a vote is called, the following decisison require Unanimity <https://en.wikipedia.org/wiki/Unanimity>.
 
-- Repository [Maintainers]: Electing new Maintainers of the same repository.
+- Repository [Maintainers][Maintainer]: Electing new Maintainers of the same repository.
 - [Oversight Committee]: Electing new Committee members.
 - [Oversight Committee]: Removing a Repository Maintainer or Committee member for any reason other than inactivity.
 
 ## Proposal Process
 
-- Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with [Maintainers], other contributors, and end [Users][User].
+- Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with [Maintainers][Maintainer], other contributors, and end users.
   Pull requests should only be merged after receiving GitHub approval from at least one Maintainer who is not the pull request author.
   Note that Flux v2 uses GitHub discussions for proposals in the `fluxcd/flux2` Git repository <https://github.com/fluxcd/flux2/discussions?discussions_q=category%3AProposals>.
 - Non-code changes should be proposed as GitHub issues.
   If unclear which Git repository to create the issue in, default to the community repository <https://github.com/fluxcd/community>.
 - All proposals should be discussed publicly in an appropriate GitHub issue or pull request.
-- If a Maintainer of an affected git repository feels feedback from specific people is warranted they will @mention those [Users] or teams to request feedback.
+- If a Maintainer of an affected git repository feels feedback from specific people is warranted they will @mention those users or teams to request feedback.
 - Proposals may also be added to the Flux Dev weekly meetings agenda, as a good avenue for making progress on a decision <https://lists.cncf.io/g/cncf-flux-dev/calendar>.
 
 ## Licenses and Copyright
@@ -108,7 +108,7 @@ Links to relevant CNCF documentation:
 - <https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist>
 - <https://github.com/cncf/foundation/blob/master/copyright-notices.md#copyright-notices>
 
-[User]: community-roles.md#user
+<!-- md links -->
 [Maintainer]: community-roles.md#maintainer
 [Oversight Committee]: community-roles.md#oversight-committee
 [community-roles.md]: community-roles.md

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -7,10 +7,6 @@ This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defi
 - [Values](#values)
   - [Code of Conduct](#code-of-conduct)
 - [Roles in the Flux Community](#roles-in-the-flux-community)
-  - [Users](#users)
-  - [Contributors](#contributors)
-  - [Maintainers](#maintainers)
-  - [Oversight Committee](#oversight-committee)
 - [Decision Making](#decision-making)
   - [Deciders](#deciders)
   - [Decision Guidelines](#decision-guidelines)
@@ -40,53 +36,7 @@ If no conclusion can be reached in meditation, such issues can be escalated to t
 
 ## Roles in the Flux Community
 
-The Flux community comprises the following roles:
-
-### Users
-
-Flux end users are the most important aspect of the community, without whom the project would have no purpose. Users are anyone who has a need for the project.
-Apart from following the Code of Conduct, there are no special requirements.
-
-### Contributors
-
-Flux welcomes all kinds of contributions, including code, issues, documentation, external tools, advocacy and community work.
-As a contributor we want to invite you to join the discussions in a variety of forums laid out in <https://github.com/fluxcd/community>.
-
-### Maintainers
-
-Maintainers are elected Contributors who showed significant and sustained contributions in a Git repository.
-Current Maintainers are listed in a `MAINTAINERS` file at the root of the Git repository.
-
-Maintainers are expected to:
-
-- Enable and promote Flux community values
-- Engage with end Users through appropriate communication channels
-- Serve as a point of conflict resolution between Contributors to their Git repository
-- Maintain open collaboration with Contributors and other Maintainers
-- Ask for help when unsure and step down considerately
-
-Maintainers will be invited to the `@fluxcd/maintainers` <https://github.com/orgs/fluxcd/teams/maintainers> team, and are members of this team for as long as they are involved with the project.
-
-### Oversight Committee
-
-This committee is responsible for the overall project, and anything not easily managed by the Maintainers of each Git repository. Including:
-
-- Overseeing the project health and growth
-- Maintaining the brand, mission, vision, values, and scope of the overall project
-- Changes to licensing and intellectual property
-- Administering access to all project assets
-- Administering Git repositories as needed
-- Handling Code of Conduct violations
-- Managing financial decisions
-- Defining the scope of each Git repository
-- Resolving escalated decisions when Maintainers responsible are blocked
-
-Ultimately the committee - after consulting with the collective of Maintainers and their community - drive the direction, values and governance of the overall project.
-
-This committee will initially be comprised of Flux Maintainers who have steered the project prior to this initial Governance document.
-The aspiration is no one company or organization should have oversight of the overall project, however that is not yet realistic at this stage. The goal is to broaden maintainership to include a wider range of organizations during CNCF incubation.
-
-Oversight Committee members are publicly listed in the `@fluxcd/oversight-committee` <https://github.com/orgs/fluxcd/teams/oversight-committee> GitHub team.
+See [community-roles.md](community-roles.md)
 
 ## Decision Making
 

--- a/OVERSIGHT.md
+++ b/OVERSIGHT.md
@@ -1,6 +1,6 @@
 # Flux Oversight Committee
 
-| Name | Slack handle | Github handle | Affiliation |
+| Name | Slack handle | GitHub handle | Affiliation |
 | -- | -- | -- | -- |
 | Hidde Beydals | `hidde` | `@hiddeco` | Weaveworks  |
 | Stefan Prodan | `stefanprodan` | `@stefanprodan` | Weaveworks  |

--- a/OVERSIGHT.md
+++ b/OVERSIGHT.md
@@ -3,5 +3,5 @@
 | Name | Slack handle | Github handle | Affiliation |
 | -- | -- | -- | -- |
 | Hidde Beydals | `hidde` | `@hiddeco` | Weaveworks  |
-| Stefan | `stefanprodan` | `@stefanprodan` | Weaveworks  |
+| Stefan Prodan | `stefanprodan` | `@stefanprodan` | Weaveworks  |
 | Michael Bridgen | `Michael Bridgen` | `@squaremo` | Weaveworks  |

--- a/OVERSIGHT.md
+++ b/OVERSIGHT.md
@@ -1,0 +1,7 @@
+# Flux Oversight Committee
+
+| Name | Slack handle | Github handle | Affiliation |
+| -- | -- | -- | -- |
+| Hidde Beydals | `hidde` | `@hiddeco` | Weaveworks  |
+| Stefan | `stefanprodan` | `@stefanprodan` | Weaveworks  |
+| Michael Bridgen | `Michael Bridgen` | `@squaremo` | Weaveworks  |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 We want the [Flux project](https://github.com/fluxcd) to be the vendor-neutral home for GitOps in a Cloud Native world.
 
-Started 2016 to automate deployments at Weaveworks, the project has grown dramatically since then. Especially since the planning of Flux v2 and GitOps Toolkit SDK it was clearer that the scope became more ambitious and that the Flux project has become the home for the Flux family of projects, all solving specific GitOps needs.
+Started 2016 to automate deployments at Weaveworks, the project has grown dramatically since then.
+Especially since the planning of Flux v2 and GitOps Toolkit SDK it was clearer that the scope became more ambitious and that the Flux project has become the home for the Flux family of projects, all solving specific GitOps needs.
 
 We also want our community to be diverse, helpful, collaborative and a fun place to be, so we would love to have you join us!
 
@@ -27,23 +28,29 @@ And there is loads more under <https://github.com/fluxcd>, we all work on this a
 
 ### Joining the community
 
-All the projects have docs to help you get started, so a first step is obviously using the projects and getting some first-hand experience. Afterwards you can help out on Slack answering questions, maybe extend the docs or fix some small issues.
+All the projects have docs to help you get started, so a first step is obviously using the projects and getting some first-hand experience.
+Afterwards you can help out on Slack answering questions, maybe extend the docs or fix some small issues.
 
 ### Teams
 
-Up until we started defining governance the Flux project had implicit teams only - if at all. In reality we all were one big team. Of course every contributing member of the community had their own area of interest and motivation.
+The Flux project uses [GitHub org teams](https://docs.github.com/en/organizations) to make it easier for [Project Members](community-roles.md#project-members) and above to communicate within and across teams.
+Members of those teams however should be defined in publicly accessible files for transparency to org non-members.
+See [community-roles.md].
 
-We are in the process of slowly formalising some team structures apart from "interest in one or more given sub-project(s)". There currently are
+The process of formalising team structures apart from "interest in one or more given sub-project(s)" is ongoing.
+There currently are:
 
 - The [Oversight committee](GOVERNANCE.md#oversight-committee)
 - The [Security team](SECURITY.md)
 - The [Community team](COMMUNITY.md)
 
-All projects and teams are open to contributors and every part of the Flux project appreciates your help and consideration. Check out the links above to learn more about the team in question.
+All projects and teams are open to contributors and every part of the Flux project appreciates your help and consideration.
+Check out the links above to learn more about the team in question.
 
 ### Meetings
 
-We run regular meetings and discuss things there. We are very happy if new users, contributors and developers join and we can put names to faces.
+We run regular meetings and discuss things there.
+We are very happy if new users, contributors and developers join and we can put names to faces.
 
 - **Meeting times**
   - "early" meeting: Uneven weeks: Wed, 12:00 UTC
@@ -132,4 +139,5 @@ To add the meetings to your e.g. Google calendar
 
 ## Rules
 
-The Flux community is governed by the [governance document](GOVERNANCE.md). We as a community follow the [code of conduct](CODE_OF_CONDUCT.md).
+The Flux community is governed by the [governance document](GOVERNANCE.md), and involvement is defined in [community-roles.md](community-roles.md).
+We as a community follow the [code of conduct](CODE_OF_CONDUCT.md).

--- a/community-roles.md
+++ b/community-roles.md
@@ -58,7 +58,7 @@ This can be through Code, Documentation, etc.
     e.g. (at)example_user
 
     ### Requirements
-    - [ ] I have reviewed the community membership guidelines [https://github.com/fluxcd/community/blob/main/community-roles.md](https://github.com/fluxcd/community/blob/main/community-roles.md)
+    - [ ] I have reviewed the community membership guidelines in `community-roles.md`
     - [ ] I have subscribed to the cncf-flux-dev e-mail list [https://lists.cncf.io/g/cncf-flux-dev/join](https://lists.cncf.io/g/cncf-flux-dev/join)
     - [ ] I am actively contributing to 1 or more `fluxcd` GitHub org repos (eg. Flux, Flagger)
     - [ ] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines

--- a/community-roles.md
+++ b/community-roles.md
@@ -1,123 +1,137 @@
+<!-- see https://github.com/yzhang-gh/vscode-markdown/blob/master/README.md#table-of-contents -->
+<!-- omit in toc -->
 # Community Roles
 
 This document outlines the different roles within the project, along with the responsibilites and privileges that come with them.
+Roles are progressive, so each include responsibilities, requirements and definitions from the previous roles.
 
-| Role                | Responsibilities                                                 | Requirements                                                                                                            | Defined by                                |
-|---------------------|------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|
-| User                | Anyone who has a need for the project                            | N/A                                                                                                                     | N/A                                       |
-| Community Member    | Participates in community                                        | N/A
-| Contributor              | Active contributor in the community                              | Sponsored by 2 maintainers, 1 Oversight Committee member and multiple contributions to a project                        | Flux org Member                           |
-| Maintainer          | Highly experienced, Active reviewer and contributor to a project | Unanimity from current maintainers, History of significant and substained contributions in a git repository             | Maintainers file entry                    |
-| Oversight Committee | Set direction and priorities of a project                        | Unanimity from current committee members, Flux maintainer who has steered project prior to Governance doc being founded | Member of oversight committee GitHub team |
+- [Roles](#roles)
+  - [Community Member](#community-member)
+  - [Project Member](#project-member)
+  - [Maintainer](#maintainer)
+  - [Oversight Committee](#oversight-committee)
+- [Proccesses](#proccesses)
+  - [Inactivity](#inactivity)
+  - [Involuntary Removal](#involuntary-removal)
+  - [Stepping Down/Emeritus Process](#stepping-downemeritus-process)
+  - [Stepping Back Into a Role](#stepping-back-into-a-role)
+  - [Contact](#contact)
 
-## Users
+## Roles
 
-Flux end users are the most important aspect of the community, without whom the project would have no purpose. Users are anyone who has a need for the project. Apart from following the Code of Conduct, there are no special requirements.
+### Community Member
 
-## Community Member
+Community Members are anyone who interacts with the project.
 
-A community member participates in the community and contributes their time, thoughts, etc. Users are anonymous users of the project - once they stop being anonymous and participate, they become a community member.
+This could be through Slack, Using the project itself, GitHub discussions, etc.
 
-### Responsibilities
+**Responsibilities:**
+
 - Must follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
 
-## Contributor
+### Project Member
 
-A contributor contributes directly to the project and adds value to it, making the maintainers' lives easier.
+Project Members are [Community Members][Community Member] who contribute directly to the project and add value to it.
+This can be through Code, Documentation, etc.
 
-**Defined by:** Member of the Flux GitHub organization
+**Defined by:** In `@fluxcd/member` GitHub team.
 
-### Requirements
-- Have made multiple contributions to the project or community. Contribution may include, but is not limited to:
+**Requirements:**
+
+- Have made multiple contributions to the project or community.
+  Contribution may include, but is not limited to:
   - Authoring or reviewing PRs on GitHub
   - Filing or commenting on issues on GitHub
-  - Contributing to project or community discussions (e.g. meetings, Slack, email discussion forums, Stack Overflow)
+  - Contributing to project or community discussions (for example meetings, Slack, email discussion forums, Stack Overflow)
 - Subscribed to the [flux-dev mailing list](https://lists.cncf.io/g/cncf-flux-dev/join)
 - Actively contributing to 1 or more projects
-- Sponsored by 2 maintainers. **Note the following requirements for sponsors:**
-  - Sponsors must have close interactions with the prospective member - e.g. code/design/proposal review, coordinating on issues, etc.
+- Sponsored by 2 maintainers.
+  **Note the following requirements for sponsors:**
+  - Sponsors must have close interactions with the prospective member - for example code/design/proposal review, coordinating on issues, etc.
   - Sponsors must be from multiple companies to demonstrate integration across community
 - Open an issue against the **flux/community** repo
   - Ensure your sponsors are @mentioned on the issue
   - Complete every item on the checklist
-  - ```markdown
-        ### GitHub Username
-        e.g. (at)example_user
 
-        ### Requirements
-        - [ ] I have reviewed the community membership guidelines [https://github.com/fluxcd/community/blob/main/community-roles.md](https://github.com/fluxcd/community/blob/main/community-roles.md)
-        - [ ] I have subscribed to the cncf-flux-dev e-mail list [https://lists.cncf.io/g/cncf-flux-dev/join](https://lists.cncf.io/g/cncf-flux-dev/join)
-        - [ ] I am actively contributing to 1 or more Flux subprojects (eg. Flux, Flagger)
-        - [ ] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines
-        - [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application
+    ```markdown
+    ### GitHub Username
+    e.g. (at)example_user
 
-        ### Sponsors
-        - (at)sponsor-1
-        - (at)sponsor-2
+    ### Requirements
+    - [ ] I have reviewed the community membership guidelines [https://github.com/fluxcd/community/blob/main/community-roles.md](https://github.com/fluxcd/community/blob/main/community-roles.md)
+    - [ ] I have subscribed to the cncf-flux-dev e-mail list [https://lists.cncf.io/g/cncf-flux-dev/join](https://lists.cncf.io/g/cncf-flux-dev/join)
+    - [ ] I am actively contributing to 1 or more Flux subprojects (eg. Flux, Flagger)
+    - [ ] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines
+    - [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application
 
-        ### List of contributions to the Flux project
-        - PRs reviewed / authored
-        - Issues responded to
-        - Flux subrojects I am involved with
+    ### Sponsors
+    - (at)sponsor-1
+    - (at)sponsor-2
+
+    ### List of contributions to the Flux project
+    - PRs reviewed / authored
+    - Discussions involved in & Issues responded to
+    - Flux subrojects I am involved with (Flagger, Flux, Controllers)
     ```
+
   - Have your sponsoring maintainers reply confirmation of sponsorship: `+1`
-  - Once your sponsors have responded, your request will be reviewed by a member of the Flux Oversight Committee. Any missing information will be requested.
+  - Once your sponsors have responded, your request will be reviewed by a member of the Flux [Oversight Committee].
+    Any missing information will be requested.
 
-## Responsibilities and privileges
+**Responsibilities and privileges:**
 
+- [Triage role](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization#repository-access-for-each-permission-level) on all `fluxcd` GitHub org repos
 - Responsive to issues and PRs assigned to them
-- At this stage, being a member is recognition / acknowledgement that does not come with any additional privileges.
 - Active owner of code they have contributed (unless ownership is explicitly transferred)
   - Code is well tested
   - Tests consistently pass
   - Addresses bugs or issues discovered after code is accepted
 - Note: members who frequently contribute code are expected to proactively perform code reviews and work towards becoming a maintainer
-- Must follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
 
-## Maintainers
+### Maintainer
 
-Maintainers are elected Contributors who showed significant and sustained contributions in a git repository.
+Maintainers are elected [Project Members][Project Member] who showed significant and sustained contributions in a git repository.
 
-**Defined by:** entry in MAINTAINERS file in a repo owned by the Flux project, member of the Flux maintainers team https://github.com/orgs/fluxcd/teams/maintainers
+**Defined by:** entry in MAINTAINERS file in a repo owned by the Flux project, and in `@fluxcd/maintainers` GitHub team.
 
-### Requirements
+**Requirements:**
 
-- Make a PR against the MAINTAINERS.md file for the subproject/repo you are 
+- Make a PR against the MAINTAINERS.md file for the subproject/repo you are
 - @mention all the other maintainers
 - Have maintainers submit their vote by `+1`
-- Once all maintainers in repo have `+1` the pr will be reviewed by a member of the Flux Oversight Committee.
+- Once all maintainers in repo have `+1` the pr will be reviewed by a member of the Flux [Oversight Committee]
 
-### Responsibilities and Privileges
+**Responsibilities and Privileges:**
 
-The following apply to the part of the codebase for which one would be in a MAINTAINERS file
-  - Enable and promote Flux community values
-  - Engage with end Users through appropriate communication channels
-  - Serve as a point of conflict resolution between Contributors to their git repository
-  - Maintain open collaboration with Contributors and other Maintainers
-  - Ask for help when unsure and step down considerately
+The following apply to the part of the codebase for which one would be in a MAINTAINERS file:
 
-The following applies everywhere
-  - Must follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
+- Enable and promote Flux community values
+- Engage with end Users through appropriate communication channels
+- Serve as a point of conflict resolution between Contributors to their git repository
+- Maintain open collaboration with Contributors and other Maintainers
+- Ask for help when unsure and step down considerately
 
-## Oversight Committee
+### Oversight Committee
 
-This committee is responsible for the overall project, and anything not easily managed by the Maintainers of each git repository.
+The Oversight Committee is responsible for the overall project, and anything not easily managed by the Maintainers of each git repository.
 
-Ultimately the committee - after consulting with the collective of Maintainers and their community - drive the direction, values and governance of the overall project.
+The committee drives the direction, values and governance of the overall project.
 
-**Defined by:** entry in org/oversight.yaml file in the flux/community repo, member of https://github.com/orgs/fluxcd/teams/oversight-committee
+The committee is currently comprised of Flux Maintainers who have steered the project prior to the initial Governance document.
 
-### Requirements
+In future, Committee Members will come from a diverse background of companies and organizations.
+Ensuring that oversight of the project is not controlled by one company or organization.
 
-At this stage this committee is comprised of Flux Maintainers who have steered the project prior to the initial Governance document
+**Defined by:** entry in OVERSIGHT.md file in the flux/community repo, and in  `@fluxcd/oversight-committee` GitHub team.
 
-The aspiration is no one company or organization should have oversight of the overall project, however that is not yet realistic at this stage. The goal is to broaden maintainership to include a wider range of organizations during CNCF incubation.
+**Requirements:**
 
-We hope to build out requirements for this role in incubation.
+We aim to build out requirements for this role during incubation. (link to issue?)
 
-### Responsibilities and Privileges
+**Responsibilities and Privileges:**
 
-The following apply to all assets across the Flux org
+The following apply to all assets across the Flux org:
+
 - Overseeing the project health and growth
 - Maintaining the brand, mission, vision, values, and scope of the overall project
 - Changes to licensing and intellectual property
@@ -128,38 +142,48 @@ The following apply to all assets across the Flux org
 - Defining the scope of each git repository
 - Resolving escalated decisions when Maintainers responsible are blocked
 
-The following applies everywhere
-  - Must follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
+## Proccesses
 
-## Inactivity
+### Inactivity
 <!--TODO: project leads to fill in exact details for how you measure inactivity for your project-->
 
-It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project. 
-* Inactivity is measured by:
-    * Periods of no contributions for longer than X months
-    * Periods of no communication for longer than X months
-* Consequences of being inactive include:
-    * Involuntary Removal
-    * Being asked to move to Emeritus status
+It is important for contributors to be and stay active to set an example and show commitment to the project.
+Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
 
+Inactivity is to be defined by the [Oversight Committee].
 
-## Involuntary Removal
-<!-- project leads may want to consider integrating this section under every role description -->
+Consequences of being inactive include:
 
-Involuntary removal of a contributor happens when responsibilities and requirements aren't being met. This may include repeated pattern of inactivity, extended period of inactivity, and/or a violation of the Code of Conduct. This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
+- Involuntary Removal
+- Being moved to Emeritus status
 
-Involuntary removal is handled by X. 
+### Involuntary Removal
 
-## Stepping Down/Emeritus Process
-If and when contributors' commitment levels change, contributors can consider stepping down (moving down a role) vs moving to emeritus status (completely stepping away from the project). 
+Involuntary removal of a contributor happens when responsibilities and requirements aren't being met.
+This may include repeated pattern of inactivity, extended period of inactivity, and/or a violation of the Code of Conduct.
+This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
 
-Please reach out to X to discuss this process.
+Involuntary removal is handled by the [Oversight Committee].
 
-## Stepping Back Into a Role
-If and when someone is available to step back into a previous contributor role, this is something that can be arranged and considered by the project oversight committee.
+### Stepping Down/Emeritus Process
 
-Please reach out to X to discuss this process.
+If and when contributors' commitment levels change, contributors can consider stepping down (moving down a role) vs moving to emeritus status (completely stepping away from the project).
 
-## Contact
-* For inquiries, please reach out to:
-    *  <!-- TODO: fill in contact info-->
+Please reach out to the [Oversight Committee] to discuss this process.
+
+### Stepping Back Into a Role
+
+If and when someone is available to step back into a previous contributor role, this is something that can be arranged and considered by the project [Oversight Committee].
+
+Please reach out to the [Oversight Committee] to discuss this process.
+
+### Contact
+
+For inquiries, please reach out to:
+
+<!-- Links -->
+[User]: #user
+[Community Member]: #community-member
+[Project Member]: #project-member
+[Maintainer]: #maintainer
+[Oversight Committee]: #oversight-committee

--- a/community-roles.md
+++ b/community-roles.md
@@ -34,7 +34,7 @@ A contributor contributes directly to the project and adds value to it, making t
   - Contributing to project or community discussions (e.g. meetings, Slack, email discussion forums, Stack Overflow)
 - Subscribed to : 
 - Actively contributing to 1 or more projects
-- Sponsored by 2 maintainers. **Not the following requirements for sponsors:**
+- Sponsored by 2 maintainers. **Note the following requirements for sponsors:**
   - Sponsors must have close interactions with the prospective member - e.g. code/design/proposal review, coordinating on issues, etc.
   - Sponsors must be from multiple companies to demonstrate integration across community
 - Open an issue against the **flux/community** repo

--- a/community-roles.md
+++ b/community-roles.md
@@ -126,7 +126,8 @@ Ensuring that oversight of the project is not controlled by one company or organ
 
 **Requirements:**
 
-We aim to build out requirements for this role during incubation. (link to issue?)
+We aim to build out requirements for the Oversight Committee role during incubation.
+See [fluxcd/community#106](https://github.com/fluxcd/community/issues/106).
 
 **Responsibilities and Privileges:**
 

--- a/community-roles.md
+++ b/community-roles.md
@@ -32,7 +32,7 @@ A contributor contributes directly to the project and adds value to it, making t
   - Authoring or reviewing PRs on GitHub
   - Filing or commenting on issues on GitHub
   - Contributing to project or community discussions (e.g. meetings, Slack, email discussion forums, Stack Overflow)
-- Subscribed to : 
+- Subscribed to the [flux-dev mailing list](https://lists.cncf.io/g/cncf-flux-dev/join)
 - Actively contributing to 1 or more projects
 - Sponsored by 2 maintainers. **Note the following requirements for sponsors:**
   - Sponsors must have close interactions with the prospective member - e.g. code/design/proposal review, coordinating on issues, etc.

--- a/community-roles.md
+++ b/community-roles.md
@@ -1,0 +1,118 @@
+# Community Roles
+
+This doc outlines the various responsibilities of community roles in Flux.
+
+
+| Role                | Responsibilities                                                 | Requirements                                                                                                            | Defined by                                |
+|---------------------|------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|
+| User                | Anyone who has a need for the project                            | N/A                                                                                                                     | N/A                                       |
+| Member              | Active contributor in the community                              | Sponsored by 2 maintainers, 1 Oversight Committee member and multiple contributions to a project                        | Flux org Member                           |
+| Maintainer          | Highly experienced, Active reviewer and contributor to a project | Unanimity from current maintainers, History of significant and substained contributions in a git repository             | Maintainers file entry                    |
+| Oversight Committee | Set direction and priorities of a project                        | Unanimity from current committee members, Flux maintainer who has steered project prior to Governance doc being founded | Member of oversight committee GitHub team |
+
+## Users
+
+Flux end users are the most important aspect of the community, without whom the project would have no purpose. Users are anyone who has a need for the project. Apart from following the Code of Conduct, there are no special requirements.
+
+## Member
+
+Members are continuously active contributors in the community.
+
+**Defined by:** Member of the Flux GitHub organization
+
+### Requirements
+- Have made multiple contributions to the project or community. Contribution may include, but is not limited to:
+  - Authoring or reviewing PRs on GitHub
+  - Filing or commenting on issues on GitHub
+  - Contributing to project or community discussions (e.g. meetings, Slack, email discussion forums, Stack Overflow)
+- Subscribed to : 
+- Actively contributing to 1 or more projects
+- Sponsored by 2 maintainers. **Not the following requirements for sponsors:**
+  - Sponsors must have close interactions with the prospective member - e.g. code/design/proposal review, coordinating on issues, etc.
+  - Sponsors must be from multiple companies to demonstrate integration across community
+- Open an issue against the **flux/community** repo
+  - Ensure your sponsors are @mentioned on the issue
+  - Complete every item on the checklist
+  - ```markdown
+        ### GitHub Username
+        e.g. (at)example_user
+
+        ### Requirements
+        - [ ] I have reviewed the community membership guidelines [https://github.com/fluxcd/community/blob/main/community-roles.md](https://github.com/fluxcd/community/blob/main/community-roles.md)
+        - [ ] I have subscribed to the cncf-flux-dev e-mail list [https://lists.cncf.io/g/cncf-flux-dev/join](https://lists.cncf.io/g/cncf-flux-dev/join)
+        - [ ] I am actively contributing to 1 or more Flux subprojects (eg. Flux, Flagger)
+        - [ ] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines
+        - [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application
+
+        ### Sponsors
+        - (at)sponsor-1
+        - (at)sponsor-2
+
+        ### List of contributions to the Flux project
+        - PRs reviewed / authored
+        - Issues responded to
+        - Flux subrojects I am involved with
+    ```
+  - Have your sponsoring maintainers reply confirmation of sponsorship: `+1`
+  - Once your sponsors have responded, your request will be reviewed by a member of the Flux Oversight Committee. Any missing information will be requested.
+
+## Responsibilities and privileges
+
+- Responsive to issues and PRs assigned to them
+- At this stage, being a member is recognition / acknowledgement that does not come with any additional privileges.
+- Active owner of code they have contributed (unless ownership is explicitly transferred)
+  - Code is well tested
+  - Tests consistently pass
+  - Addresses bugs or issues discovered after code is accepted
+- Note: members who frequently contribute code are expected to proactively perform code reviews and work towards becoming a maintainer
+
+## Maintainers
+
+Maintainers are elected Contributors who showed significant and sustained contributions in a git repository.
+
+**Defined by:** entry in MAINTAINERS file in a repo owned by the Flux project, member of the Flux maintainers team https://github.com/orgs/fluxcd/teams/maintainers
+
+### Requirements
+
+- Make a PR against the MAINTAINERS.md file for the subproject/repo you are 
+- @mention all the other maintainers
+- Have maintainers submit their vote by `+1`
+- Once all maintainers in repo have `+1` the pr will be reviewed by a member of the Flux Oversight Committee.
+
+### Responsibilities and Privileges
+
+The following apply to the part of the codebase for which one would be in a MAINTAINERS file
+  - Enable and promote Flux community values
+  - Engage with end Users through appropriate communication channels
+  - Serve as a point of conflict resolution between Contributors to their git repository
+  - Maintain open collaboration with Contributors and other Maintainers
+  - Ask for help when unsure and step down considerately
+
+## Oversight Committee
+
+This committee is responsible for the overall project, and anything not easily managed by the Maintainers of each git repository.
+
+Ultimately the committee - after consulting with the collective of Maintainers and their community - drive the direction, values and governance of the overall project.
+
+**Defined by:** entry in org/oversight.yaml file in the flux/community repo, member of https://github.com/orgs/fluxcd/teams/oversight-committee
+
+### Requirements
+
+At this stage this committee is comprised of Flux Maintainers who have steered the project prior to the initial Governance document
+
+The aspiration is no one company or organization should have oversight of the overall project, however that is not yet realistic at this stage. The goal is to broaden maintainership to include a wider range of organizations during CNCF incubation.
+
+We hope to build out requirements for this role in incubation.
+
+### Responsibilities and Privileges
+
+The following apply to all assets across the Flux org
+- Overseeing the project health and growth
+- Maintaining the brand, mission, vision, values, and scope of the overall project
+- Changes to licensing and intellectual property
+- Administering access to all project assets
+- Administering git repositories as needed
+- Handling Code of Conduct violations
+- Managing financial decisions
+- Defining the scope of each git repository
+- Resolving escalated decisions when Maintainers responsible are blocked

--- a/community-roles.md
+++ b/community-roles.md
@@ -71,7 +71,7 @@ This can be through Code, Documentation, etc.
     ### List of contributions to the Flux project
     - PRs reviewed / authored
     - Discussions involved in & Issues responded to
-    - Flux subrojects I am involved with (Flagger, Flux, Controllers)
+    - Flux subprojects I am involved with (Flagger, Flux, Controllers)
     ```
 
   - Have your sponsoring maintainers reply confirmation of sponsorship: `+1`

--- a/community-roles.md
+++ b/community-roles.md
@@ -21,9 +21,9 @@ Roles are progressive, so each include responsibilities, requirements and defini
 
 ### Community Member
 
-Community Members are anyone who interacts with the project.
+Community Members are any user who interacts with the project.
 
-This could be through Slack, Using the project itself, GitHub discussions, etc.
+This could be through Slack, using the project itself, GitHub discussions, etc.
 
 **Responsibilities:**
 
@@ -181,8 +181,7 @@ Please reach out to the [Oversight Committee] to discuss this process.
 
 For inquiries, please reach out to:
 
-<!-- Links -->
-[User]: #user
+<!-- md links -->
 [Community Member]: #community-member
 [Project Member]: #project-member
 [Maintainer]: #maintainer

--- a/community-roles.md
+++ b/community-roles.md
@@ -179,7 +179,7 @@ Please reach out to the [Oversight Committee] to discuss this process.
 
 ### Contact
 
-For inquiries, please reach out to:
+For inquiries, please reach out to: <cncf-flux-oversight-committee@lists.cncf.io>
 
 <!-- md links -->
 [Community Member]: #community-member

--- a/community-roles.md
+++ b/community-roles.md
@@ -44,7 +44,7 @@ This can be through Code, Documentation, etc.
   - Filing or commenting on issues on GitHub
   - Contributing to project or community discussions (for example meetings, Slack, email discussion forums, Stack Overflow)
 - Subscribed to the [flux-dev mailing list](https://lists.cncf.io/g/cncf-flux-dev/join)
-- Actively contributing to 1 or more projects
+- Actively contributing to 1 or more `fluxcd` GitHub org repos
 - Sponsored by 2 maintainers.
   **Note the following requirements for sponsors:**
   - Sponsors must have close interactions with the prospective member - for example code/design/proposal review, coordinating on issues, etc.
@@ -60,7 +60,7 @@ This can be through Code, Documentation, etc.
     ### Requirements
     - [ ] I have reviewed the community membership guidelines [https://github.com/fluxcd/community/blob/main/community-roles.md](https://github.com/fluxcd/community/blob/main/community-roles.md)
     - [ ] I have subscribed to the cncf-flux-dev e-mail list [https://lists.cncf.io/g/cncf-flux-dev/join](https://lists.cncf.io/g/cncf-flux-dev/join)
-    - [ ] I am actively contributing to 1 or more Flux subprojects (eg. Flux, Flagger)
+    - [ ] I am actively contributing to 1 or more `fluxcd` GitHub org repos (eg. Flux, Flagger)
     - [ ] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines
     - [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application
 
@@ -96,8 +96,8 @@ Maintainers are elected [Project Members][Project Member] who showed significant
 
 **Requirements:**
 
-- Make a PR against the MAINTAINERS.md file for the subproject/repo you are
-- @mention all the other maintainers
+- Make a PR against the `MAINTAINERS` file for a `fluxcd` GitHub org repo
+- @mention all the other current maintainers
 - Have maintainers submit their vote by `+1`
 - Once all maintainers in repo have `+1` the pr will be reviewed by a member of the Flux [Oversight Committee]
 
@@ -122,7 +122,7 @@ The committee is currently comprised of Flux Maintainers who have steered the pr
 In future, Committee Members will come from a diverse background of companies and organizations.
 Ensuring that oversight of the project is not controlled by one company or organization.
 
-**Defined by:** entry in OVERSIGHT.md file in the flux/community repo, and in  `@fluxcd/oversight-committee` GitHub team.
+**Defined by:** entry in `OVERSIGHT.md` file in the flux/community repo, and in  `@fluxcd/oversight-committee` GitHub team.
 
 **Requirements:**
 

--- a/community-roles.md
+++ b/community-roles.md
@@ -1,12 +1,12 @@
 # Community Roles
 
-This doc outlines the various responsibilities of community roles in Flux.
-
+This document outlines the different roles within the project, along with the responsibilites and privileges that come with them.
 
 | Role                | Responsibilities                                                 | Requirements                                                                                                            | Defined by                                |
 |---------------------|------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|
 | User                | Anyone who has a need for the project                            | N/A                                                                                                                     | N/A                                       |
-| Member              | Active contributor in the community                              | Sponsored by 2 maintainers, 1 Oversight Committee member and multiple contributions to a project                        | Flux org Member                           |
+| Community Member    | Participates in community                                        | N/A
+| Contributor              | Active contributor in the community                              | Sponsored by 2 maintainers, 1 Oversight Committee member and multiple contributions to a project                        | Flux org Member                           |
 | Maintainer          | Highly experienced, Active reviewer and contributor to a project | Unanimity from current maintainers, History of significant and substained contributions in a git repository             | Maintainers file entry                    |
 | Oversight Committee | Set direction and priorities of a project                        | Unanimity from current committee members, Flux maintainer who has steered project prior to Governance doc being founded | Member of oversight committee GitHub team |
 
@@ -14,9 +14,16 @@ This doc outlines the various responsibilities of community roles in Flux.
 
 Flux end users are the most important aspect of the community, without whom the project would have no purpose. Users are anyone who has a need for the project. Apart from following the Code of Conduct, there are no special requirements.
 
-## Member
+## Community Member
 
-Members are continuously active contributors in the community.
+A community member participates in the community and contributes their time, thoughts, etc. Users are anonymous users of the project - once they stop being anonymous and participate, they become a community member.
+
+### Responsibilities
+- Must follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
+
+## Contributor
+
+A contributor contributes directly to the project and adds value to it, making the maintainers' lives easier.
 
 **Defined by:** Member of the Flux GitHub organization
 
@@ -65,6 +72,7 @@ Members are continuously active contributors in the community.
   - Tests consistently pass
   - Addresses bugs or issues discovered after code is accepted
 - Note: members who frequently contribute code are expected to proactively perform code reviews and work towards becoming a maintainer
+- Must follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
 
 ## Maintainers
 
@@ -87,6 +95,9 @@ The following apply to the part of the codebase for which one would be in a MAIN
   - Serve as a point of conflict resolution between Contributors to their git repository
   - Maintain open collaboration with Contributors and other Maintainers
   - Ask for help when unsure and step down considerately
+
+The following applies everywhere
+  - Must follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
 
 ## Oversight Committee
 
@@ -116,3 +127,39 @@ The following apply to all assets across the Flux org
 - Managing financial decisions
 - Defining the scope of each git repository
 - Resolving escalated decisions when Maintainers responsible are blocked
+
+The following applies everywhere
+  - Must follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
+
+## Inactivity
+<!--TODO: project leads to fill in exact details for how you measure inactivity for your project-->
+
+It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project. 
+* Inactivity is measured by:
+    * Periods of no contributions for longer than X months
+    * Periods of no communication for longer than X months
+* Consequences of being inactive include:
+    * Involuntary Removal
+    * Being asked to move to Emeritus status
+
+
+## Involuntary Removal
+<!-- project leads may want to consider integrating this section under every role description -->
+
+Involuntary removal of a contributor happens when responsibilities and requirements aren't being met. This may include repeated pattern of inactivity, extended period of inactivity, and/or a violation of the Code of Conduct. This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
+
+Involuntary removal is handled by X. 
+
+## Stepping Down/Emeritus Process
+If and when contributors' commitment levels change, contributors can consider stepping down (moving down a role) vs moving to emeritus status (completely stepping away from the project). 
+
+Please reach out to X to discuss this process.
+
+## Stepping Back Into a Role
+If and when someone is available to step back into a previous contributor role, this is something that can be arranged and considered by the project oversight committee.
+
+Please reach out to X to discuss this process.
+
+## Contact
+* For inquiries, please reach out to:
+    *  <!-- TODO: fill in contact info-->


### PR DESCRIPTION
This PR expands on the roles set out in GOVERNANCE

## Big changes

### Replace the Contributor role, with a member role with new requirements

Provides a stepping stone between starting to contribute, and becoming a flux maintainer

### Attempt to flesh out the requirements on how one becomes a maintainer

Needs feedback from current maintainers on how that works

### Information shifted from governance into community roles

I've tried to shift everything in the roles section into roles doc which states
- what the role is
- how the role is defined
- the requirements
- the responsibilities and privileges

## Feedback welcome and requested
Would like Feedback from current flux Oversight committee and maintainers to see if theres anything that I have missed, or incorrectly assumed / stated

Need more details on what level of github privileges are for maintainer and oversight to add to respective sections

Fixes https://github.com/fluxcd/community/issues/64