### PR TITLE
Fix script in GitHub actions

### DIFF
--- a/project/get_project_data
+++ b/project/get_project_data
@@ -1,9 +1,20 @@
 #!/usr/bin/python
 
+import glob
 import os
 import re
 import sys
 from urllib.request import urlopen
+
+# I hate doing this... but we've got to make this work on Github Actions...
+
+if os.path.exists('/opt/hostedtoolcache/Python'):
+    VERSION_INFO = sys.version_info
+    LOCATION = '/opt/hostedtoolcache/Python/{}.{}.*/*/lib/python*/site-packages'.format(
+        VERSION_INFO.major, VERSION_INFO.minor)
+    LOCAL_PY_PATHS = glob.glob(LOCATION)
+    if LOCAL_PY_PATHS and LOCAL_PY_PATHS[0] not in sys.path:
+        sys.path.append(LOCAL_PY_PATHS[0])
 
 from ruamel import yaml
 from ruamel.yaml.comments import CommentedSeq


### PR DESCRIPTION
	Refer to https://github.com/fluxcd/website/blob/main/hack/contributors.py#L7-L16

Broken as in https://github.com/fluxcd/community/runs/4521945608?check_suite_focus=true

```python
Traceback (most recent call last):
  File "./project/get_project_data", line 8, in <module>
    from ruamel import yaml
ModuleNotFoundError: No module named 'ruamel'
```
