### PR TITLE
Ignore link checks for twitter.com/fluxcd

### DIFF
--- a/.github/workflows/lychee-cron.yaml
+++ b/.github/workflows/lychee-cron.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.2.0
         with:
-          args: --verbose --no-progress **/*.md
+          args: --verbose --no-progress **/*.md --exclude-file .lycheeignore
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/lychee-pr.yaml
+++ b/.github/workflows/lychee-pr.yaml
@@ -9,6 +9,6 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.2.0
         with:
-          args: --verbose --no-progress **/*.md
+          args: --verbose --no-progress **/*.md --exclude-file .lycheeignore
       - name: Fail if there were link errors
         run: exit ${{ steps.lychee.outputs.exit_code }}

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+https://twitter.com/fluxcd
+


### PR DESCRIPTION
Twitter's throttling process confuses linkchecker, resulting in intermittent
false positives when trying to validate fluxcd's twitter URL.

Fixes https://github.com/fluxcd/community/issues/164 https://github.com/fluxcd/community/issues/162