### PR TITLE
Simplify lychee args

### DIFF
--- a/.github/workflows/lychee-cron.yaml
+++ b/.github/workflows/lychee-cron.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.3.0
         with:
-          args: --verbose --no-progress '**/*.md' --exclude-file .lycheeignore
+          args: --verbose --no-progress .
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/lychee-pr.yaml
+++ b/.github/workflows/lychee-pr.yaml
@@ -9,6 +9,5 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.3.0
         with:
-          args: --verbose --no-progress '**/*.md' --exclude-file .lycheeignore
-      - name: Fail if there were link errors
-        run: exit ${{ steps.lychee.outputs.exit_code }}
+          args: --verbose --no-progress .
+          fail: true


### PR DESCRIPTION
Follow-up to #173
- .lycheeignore is picked up by default now
- use 'fail: true' to indicate failing when links can't be
  verified

Signed-off-by: Daniel Holbach <daniel@weave.works>