### PR TITLE
Replace Flux Oversight Committee

### DIFF
--- a/CORE-MAINTAINERS
+++ b/CORE-MAINTAINERS
@@ -1,0 +1,21 @@
+The maintainers are generally available in Slack at
+https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages/CLAJ40HV3)
+(obtain an invitation at https://slack.cncf.io/).
+
+These maintainers are shared with other Flux v2-related git
+repositories under https://github.com/fluxcd, as noted in their
+respective MAINTAINERS files.
+
+For convenience, they are reflected in the GitHub team
+@fluxcd/core-maintainers -- if the list here changes, that team also
+should.
+
+In alphabetical order:
+
+Aurel Canciu, NexHealth <aurel.canciu@nexhealth.com> (github: @relu, slack: relu)
+Hidde Beydals, Weaveworks <hidde@weave.works> (github: @hiddeco, slack: hidde)
+Max Jonas Werner, D2iQ <max@e13.dev> (github: @makkes, slack: max)
+Paulo Gomes, Weaveworks <paulo.gomes@weave.works> (github: @pjbgf, slack: pjbgf)
+Philip Laine, Xenit <philip.laine@xenit.se> (github: @phillebaba, slack: phillebaba)
+Stefan Prodan, Weaveworks <stefan@weave.works> (github: @stefanprodan, slack: stefanprodan)
+Sunny, Weaveworks <sunny@weave.works> (github: @darkowlzz, slack: darkowlzz)

--- a/CORE-MAINTAINERS
+++ b/CORE-MAINTAINERS
@@ -2,7 +2,7 @@ The maintainers are generally available in Slack at
 https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages/CLAJ40HV3)
 (obtain an invitation at https://slack.cncf.io/).
 
-These maintainers are shared with other Flux v2-related git
+These maintainers are shared with other Flux v2-related Git
 repositories under https://github.com/fluxcd, as noted in their
 respective MAINTAINERS files.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,6 +6,7 @@ This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defi
 
 - [Values](#values)
   - [Code of Conduct](#code-of-conduct)
+  - [Meetings](#meetings)
 - [Roles and Process in the Flux Community](#roles-and-process-in-the-flux-community)
 - [Decision Making](#decision-making)
   - [Deciders](#deciders)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -96,8 +96,7 @@ If a vote is called, the following decisions require a Supermajority Vote <https
 If a vote is called, the following decision require Unanimity <https://en.wikipedia.org/wiki/Unanimity>.
 
 - Repository [Maintainers][Maintainer]: Electing new Maintainers of the same repository.
-- [flux2 maintainers]: Electing new Committee members.
-- [flux2 maintainers]: Removing a Repository Maintainer or Committee member for any reason other than inactivity.
+- [flux2 maintainers]: Removing a Maintainer for any reason other than inactivity.
 
 ## Licenses and Copyright
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -13,6 +13,7 @@ This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defi
   - [Decision Guidelines](#decision-guidelines)
   - [Simple Majority Decisions](#simple-majority-decisions)
   - [Supermajority Decisions](#supermajority-decisions)
+  - [Unanimity Decisions](#unanimity-decisions)
 - [Licenses and Copyright](#licenses-and-copyright)
 
 ## Values
@@ -76,7 +77,7 @@ If we fail to make a decision or the picture was unclear, we found that we neede
       This should be rare, due to the social cost of discontinuing the Consensus process for this reason.
       Most decisions should wait for the above process to take its course.
 - If Deciders agree to a vote, the default is a Simple Majority.
-- However, there are cases that require stronger voting – Supermajority – specified below:
+- However, there are cases that require stronger voting – Supermajority or Unanimity – specified below:
 
 ### Simple Majority Decisions
 
@@ -86,15 +87,20 @@ If a vote is called, the default is a Simple Majority Vote – more than half o
 
 If a vote is called, the following decisions require a Supermajority Vote – two-thirds or more of all [Deciders](#deciders):
 
-- Repository [Maintainers][Maintainer]: Electing new Maintainers of the same repository.
 - [core maintainers]: Enforcing a Code of Conduct violation by a community member.
-- [core maintainers]: Removing a Maintainer of any repository for any reason other than inactivity.
 - [core maintainers]: Licensing and intellectual property changes.
 - [core maintainers]: Material changes to the Governance document.
   - Note: editorial changes to governance may be made by lazy consensus, unless challenged.
     These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.
     They do not change the intention or meaning of anything in this document.
 - [core maintainers]: Elect new [org admins].
+
+### Unanimity Decisions
+
+For these kinds of decisions, a deadline can be given, and unanimity with a quorum of 2/3 is sufficient. That means people can be silent, but everyone who speaks must agree.
+
+- Repository [Maintainers][Maintainer]: Electing new Maintainers of the same repository.
+- [core maintainers]: Removing a Maintainer of any repository for any reason other than inactivity.
 
 ## Licenses and Copyright
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -56,7 +56,7 @@ If we fail to make a decision or the picture was unclear, we found that we neede
 ### Deciders
 
 - Repository [Maintainers][Maintainer]: Decisions that affect only one git repository.
-- [flux2 maintainers]: Decisions that are outside the scope of a single git repository.
+- [core maintainers]: Decisions that are outside the scope of a single git repository.
 
 ### Decision Guidelines
 
@@ -66,8 +66,8 @@ If we fail to make a decision or the picture was unclear, we found that we neede
 - If an objection is raised through the Lazy Consensus process, Deciders work together to seek an agreeable solution.
 - If Consensus can not be reached, but a decision must be made, the next step is try to attempt to agree that a vote should be called.
   This is important, as it gives dissenting views a chance to request more information or raise further points.
-  If Deciders are the [flux2 maintainers], part of that responsibility is the final point of escalation, so agreeing to a vote is assumed if timeline doesn't allow the consensus process to continue.
-- If Deciders are Repository [Maintainers][Maintainer], and they can't agree on calling a vote, they may escalate to the [flux2 maintainers].
+  If Deciders are the [core maintainers], part of that responsibility is the final point of escalation, so agreeing to a vote is assumed if timeline doesn't allow the consensus process to continue.
+- If Deciders are Repository [Maintainers][Maintainer], and they can't agree on calling a vote, they may escalate to the [core maintainers].
   This should only be done at this stage if:
   1. An unmovable deadline is threatened by continuing the Consensus process; or
   2. A Decider feels there is unreasonable blocking of both reaching Consensus and agreeing to a vote.
@@ -85,10 +85,10 @@ If a vote is called, the default is a Simple Majority Vote – more than half o
 If a vote is called, the following decisions require a Supermajority Vote – two-thirds or more of all [Deciders](#deciders):
 
 - Repository [Maintainers][Maintainer]: Electing new Maintainers of the same repository.
-- [flux2 maintainers]: Enforcing a Code of Conduct violation by a community member.
-- [flux2 maintainers]: Removing a Maintainer of any repository for any reason other than inactivity.
-- [flux2 maintainers]: Licensing and intellectual property changes.
-- [flux2 maintainers]: Material changes to the Governance document.
+- [core maintainers]: Enforcing a Code of Conduct violation by a community member.
+- [core maintainers]: Removing a Maintainer of any repository for any reason other than inactivity.
+- [core maintainers]: Licensing and intellectual property changes.
+- [core maintainers]: Material changes to the Governance document.
   - Note: editorial changes to governance may be made by lazy consensus, unless challenged.
     These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.
     They do not change the intention or meaning of anything in this document.
@@ -106,5 +106,5 @@ Links to relevant CNCF documentation:
 
 <!-- md links -->
 [Maintainer]: community-roles.md#maintainer
-[flux2 maintainers]: community-roles.md#flux2-maintainers
+[core maintainers]: community-roles.md#core-maintainers
 [community-roles.md]: community-roles.md

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -38,6 +38,10 @@ See
 
 ## Decision Making
 
+While we spell out all the possibilities for decision making and possible eventualities below, the Flux project almost always looked for and found consensus. Using lazy consensus never resulted in later disputes. Our communication channels (public meetings, Slack, RFCs, etc) provide us with the means to have agreement before we set up a vote.
+
+If we fail to make a decision or the picture was unclear, we found that we needed more information. In these cases, we reach out to users, adjacent projects or counterpart teams in the CNCF.
+
 ### Deciders
 
 - Repository [Maintainers][Maintainer]: Decisions that affect only one git repository.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -44,8 +44,8 @@ accused of a CoC violation.
 
 See
 
-- [community-roles.md] for the definition of roles in our community and
-- [PROCESS.md] to understand how to interact with Flux Community processes
+- [community-roles.md](community-roles.md) for the definition of roles in our community and
+- [PROCESS.md](PROCESS.md) to understand how to interact with Flux Community processes
 
 ## Decision Making
 
@@ -55,8 +55,8 @@ If we fail to make a decision or the picture was unclear, we found that we neede
 
 ### Deciders
 
-- Repository [Maintainers][Maintainer]: Decisions that affect only one git repository.
-- [core maintainers]: Decisions that are outside the scope of a single git repository.
+- Repository [Maintainers][Maintainer]: Decisions that affect only one Git repository.
+- [core maintainers]: Decisions that are outside the scope of a single Git repository.
 
 ### Decision Guidelines
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -77,11 +77,11 @@ If we fail to make a decision or the picture was unclear, we found that we neede
 
 ### Simple Majority Decisions
 
-If a vote is called, the default is a Simple Majority Vote <https://en.wikipedia.org/wiki/Majority>.
+If a vote is called, the default is a Simple Majority Vote – more than half of [Deciders](#deciders).
 
 ### Supermajority Decisions
 
-If a vote is called, the following decisions require a Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority>.
+If a vote is called, the following decisions require a Supermajority Vote – two-thirds of [Deciders](#deciders):
 
 - Repository [Maintainers][Maintainer]: Electing new Maintainers of the same repository.
 - [flux2 maintainers]: Enforcing a Code of Conduct violation by a community member.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,14 +6,13 @@ This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defi
 
 - [Values](#values)
   - [Code of Conduct](#code-of-conduct)
-- [Roles in the Flux Community](#roles-in-the-flux-community)
+- [Roles and Process in the Flux Community](#roles-and-process-in-the-flux-community)
 - [Decision Making](#decision-making)
   - [Deciders](#deciders)
   - [Decision Guidelines](#decision-guidelines)
   - [Simple Majority Decisions](#simple-majority-decisions)
   - [Supermajority Decisions](#supermajority-decisions)
   - [Unanimity Decisions](#unanimity-decisions)
-- [Proposal Process](#proposal-process)
 - [Licenses and Copyright](#licenses-and-copyright)
 
 ## Values
@@ -30,13 +29,12 @@ Flux strives to operate independently of specific partisan interests, and for de
 
 The Flux community adheres to the CNCF Code of Conduct <https://github.com/cncf/foundation/blob/master/code-of-conduct.md>.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a _Flux_ [flux2 maintainers] member.
+## Roles and Process in the Flux Community
 
-If no conclusion can be reached in meditation, such issues can be escalated to the CNCF mediator, Mishi Choudhary <mishi@linux.com>, in which case CNCF may choose to intervene.
+See
 
-## Roles in the Flux Community
-
-See [community-roles.md]
+- [community-roles.md] for the definition of roles in our community and
+- [PROCESS.md] to understand how to interact with Flux Community processes
 
 ## Decision Making
 
@@ -47,7 +45,7 @@ See [community-roles.md]
 
 ### Decision Guidelines
 
-- Decisions that warrant wider input should be made public by using the below guidelines in combination with the Proposal Process below.
+- Decisions that warrant wider input should be made public by using the below guidelines in combination with the [Proposal Process](PROCESS.md#proposal-process).
 - Whether or not wider input is required, the Flux community believes that the best decisions are reached through Consensus <https://en.wikipedia.org/wiki/Consensus_decision-making>.
 - Most decisions start by seeking Lazy Consensus <https://communitymgt.wikia.com/wiki/Lazy_consensus>.
 - If an objection is raised through the Lazy Consensus process, Deciders work together to seek an agreeable solution.
@@ -85,18 +83,6 @@ If a vote is called, the following decision require Unanimity <https://en.wikipe
 - Repository [Maintainers][Maintainer]: Electing new Maintainers of the same repository.
 - [flux2 maintainers]: Electing new Committee members.
 - [flux2 maintainers]: Removing a Repository Maintainer or Committee member for any reason other than inactivity.
-
-## Proposal Process
-
-- Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with [Maintainers][Maintainer], other contributors, and end users.
-  Pull requests should only be merged after receiving GitHub approval from at least one Maintainer who is not the pull request author.
-- For architectural changes to Flux, please use the [RFC process](https://github.com/fluxcd/flux2/tree/main/rfcs).  
-  Note that Flux v2 uses GitHub discussions for (non-architectural) proposals in the `fluxcd/flux2` Git repository <https://github.com/fluxcd/flux2/discussions?discussions_q=category%3AProposals>.
-- Non-code changes should be proposed as GitHub issues.
-  If unclear which Git repository to create the issue in, default to the community repository <https://github.com/fluxcd/community>.
-- All proposals should be discussed publicly in an appropriate GitHub issue or pull request.
-- If a Maintainer of an affected git repository feels feedback from specific people is warranted they will @mention those users or teams to request feedback.
-- Proposals may also be added to the Flux Dev weekly meetings agenda, as a good avenue for making progress on a decision <https://lists.cncf.io/g/cncf-flux-dev/calendar>.
 
 ## Licenses and Copyright
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -30,7 +30,7 @@ Flux strives to operate independently of specific partisan interests, and for de
 
 The Flux community adheres to the CNCF Code of Conduct <https://github.com/cncf/foundation/blob/master/code-of-conduct.md>.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a _Flux_ [Oversight Committee] member.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a _Flux_ [flux2 maintainers] member.
 
 If no conclusion can be reached in meditation, such issues can be escalated to the CNCF mediator, Mishi Choudhary <mishi@linux.com>, in which case CNCF may choose to intervene.
 
@@ -43,7 +43,7 @@ See [community-roles.md]
 ### Deciders
 
 - Repository [Maintainers][Maintainer]: Decisions that affect only one git repository.
-- [Oversight Committee]: Decisions that are outside the scope of a single git repository.
+- [flux2 maintainers]: Decisions that are outside the scope of a single git repository.
 
 ### Decision Guidelines
 
@@ -53,8 +53,8 @@ See [community-roles.md]
 - If an objection is raised through the Lazy Consensus process, Deciders work together to seek an agreeable solution.
 - If Consensus can not be reached, but a decision must be made, the next step is try to attempt to agree that a vote should be called.
   This is important, as it gives dissenting views a chance to request more information or raise further points.
-  If Deciders are the [Oversight Committee], part of that responsibility is the final point of escalation, so agreeing to a vote is assumed if timeline doesn't allow the consensus process to continue.
-- If Deciders are Repository [Maintainers][Maintainer], and they can't agree on calling a vote, they may escalate to the [Oversight Committee].
+  If Deciders are the [flux2 maintainers], part of that responsibility is the final point of escalation, so agreeing to a vote is assumed if timeline doesn't allow the consensus process to continue.
+- If Deciders are Repository [Maintainers][Maintainer], and they can't agree on calling a vote, they may escalate to the [flux2 maintainers].
   This should only be done at this stage if:
   1. An unmovable deadline is threatened by continuing the Consensus process; or
   2. A Decider feels there is unreasonable blocking of both reaching Consensus and agreeing to a vote.
@@ -71,9 +71,9 @@ If a vote is called, the default is a Simple Majority Vote <https://en.wikipedia
 
 If a vote is called, the following decisions require a Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority>.
 
-- [Oversight Committee]: Enforcing a Code of Conduct violation by a community member.
-- [Oversight Committee]: Licensing and intellectual property changes.
-- [Oversight Committee]: Material changes to the Governance document.
+- [flux2 maintainers]: Enforcing a Code of Conduct violation by a community member.
+- [flux2 maintainers]: Licensing and intellectual property changes.
+- [flux2 maintainers]: Material changes to the Governance document.
   - Note: editorial changes to governance may be made by lazy consensus, unless challenged.
     These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.
     They do not change the intention or meaning of anything in this document.
@@ -83,8 +83,8 @@ If a vote is called, the following decisions require a Supermajority Vote <https
 If a vote is called, the following decision require Unanimity <https://en.wikipedia.org/wiki/Unanimity>.
 
 - Repository [Maintainers][Maintainer]: Electing new Maintainers of the same repository.
-- [Oversight Committee]: Electing new Committee members.
-- [Oversight Committee]: Removing a Repository Maintainer or Committee member for any reason other than inactivity.
+- [flux2 maintainers]: Electing new Committee members.
+- [flux2 maintainers]: Removing a Repository Maintainer or Committee member for any reason other than inactivity.
 
 ## Proposal Process
 
@@ -111,5 +111,5 @@ Links to relevant CNCF documentation:
 
 <!-- md links -->
 [Maintainer]: community-roles.md#maintainer
-[Oversight Committee]: community-roles.md#oversight-committee
+[flux2 maintainers]: community-roles.md#flux2-maintainers
 [community-roles.md]: community-roles.md

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -40,6 +40,8 @@ Maintainer on receipt of a security issue or CoC report.  All current Maintainer
 must be invited to such closed meetings, except for any Maintainer who is
 accused of a CoC violation.
 
+Note: Refer to [our security process](https://fluxcd.io/security) for more information on how security issues are handled in particular.
+
 ## Roles and Process in the Flux Community
 
 See

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,7 +12,6 @@ This document <https://github.com/fluxcd/community/blob/main/GOVERNANCE.md> defi
   - [Decision Guidelines](#decision-guidelines)
   - [Simple Majority Decisions](#simple-majority-decisions)
   - [Supermajority Decisions](#supermajority-decisions)
-  - [Unanimity Decisions](#unanimity-decisions)
 - [Licenses and Copyright](#licenses-and-copyright)
 
 ## Values
@@ -74,7 +73,7 @@ If we fail to make a decision or the picture was unclear, we found that we neede
       This should be rare, due to the social cost of discontinuing the Consensus process for this reason.
       Most decisions should wait for the above process to take its course.
 - If Deciders agree to a vote, the default is a Simple Majority.
-- However, there are cases that require stronger voting – Supermajority or Unanimity – specified below:
+- However, there are cases that require stronger voting – Supermajority – specified below:
 
 ### Simple Majority Decisions
 
@@ -84,19 +83,14 @@ If a vote is called, the default is a Simple Majority Vote <https://en.wikipedia
 
 If a vote is called, the following decisions require a Supermajority Vote <https://en.wikipedia.org/wiki/Supermajority>.
 
+- Repository [Maintainers][Maintainer]: Electing new Maintainers of the same repository.
 - [flux2 maintainers]: Enforcing a Code of Conduct violation by a community member.
+- [flux2 maintainers]: Removing a Maintainer of any repository for any reason other than inactivity.
 - [flux2 maintainers]: Licensing and intellectual property changes.
 - [flux2 maintainers]: Material changes to the Governance document.
   - Note: editorial changes to governance may be made by lazy consensus, unless challenged.
     These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.
     They do not change the intention or meaning of anything in this document.
-
-### Unanimity Decisions
-
-If a vote is called, the following decision require Unanimity <https://en.wikipedia.org/wiki/Unanimity>.
-
-- Repository [Maintainers][Maintainer]: Electing new Maintainers of the same repository.
-- [flux2 maintainers]: Removing a Maintainer for any reason other than inactivity.
 
 ## Licenses and Copyright
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -27,7 +27,7 @@ Flux strives to operate independently of specific partisan interests, and for de
 
 ### Code of Conduct
 
-The Flux community adheres to the CNCF Code of Conduct <https://github.com/cncf/foundation/blob/master/code-of-conduct.md>.
+[Code of Conduct](CODE_OF_CONDUCT.md) violations by community members will be discussed and resolved on the [private Maintainer mailing list](mailto:cncf-flux-maintainers@lists.cncf.io). If the reported CoC violator is a Maintainer, the Maintainers will instead designate two Maintainers to work with CNCF staff in resolving the report.
 
 ## Roles and Process in the Flux Community
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -29,6 +29,17 @@ Flux strives to operate independently of specific partisan interests, and for de
 
 [Code of Conduct](CODE_OF_CONDUCT.md) violations by community members will be discussed and resolved on the [private Maintainer mailing list](mailto:cncf-flux-maintainers@lists.cncf.io). If the reported CoC violator is a Maintainer, the Maintainers will instead designate two Maintainers to work with CNCF staff in resolving the report.
 
+### Meetings
+
+Time zones permitting, Maintainers are expected to participate in the [public
+developer meeting](README.md#meetings).
+
+Maintainers will also have closed meetings in order to discuss security reports
+or Code of Conduct violations.  Such meetings should be scheduled by any
+Maintainer on receipt of a security issue or CoC report.  All current Maintainers
+must be invited to such closed meetings, except for any Maintainer who is
+accused of a CoC violation.
+
 ## Roles and Process in the Flux Community
 
 See

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -78,11 +78,11 @@ If we fail to make a decision or the picture was unclear, we found that we neede
 
 ### Simple Majority Decisions
 
-If a vote is called, the default is a Simple Majority Vote – more than half of [Deciders](#deciders).
+If a vote is called, the default is a Simple Majority Vote – more than half of all [Deciders](#deciders).
 
 ### Supermajority Decisions
 
-If a vote is called, the following decisions require a Supermajority Vote – two-thirds of [Deciders](#deciders):
+If a vote is called, the following decisions require a Supermajority Vote – two-thirds or more of all [Deciders](#deciders):
 
 - Repository [Maintainers][Maintainer]: Electing new Maintainers of the same repository.
 - [flux2 maintainers]: Enforcing a Code of Conduct violation by a community member.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -92,6 +92,7 @@ If a vote is called, the following decisions require a Supermajority Vote – t
   - Note: editorial changes to governance may be made by lazy consensus, unless challenged.
     These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.
     They do not change the intention or meaning of anything in this document.
+- [core maintainers]: Elect new [org admins].
 
 ## Licenses and Copyright
 
@@ -107,4 +108,5 @@ Links to relevant CNCF documentation:
 <!-- md links -->
 [Maintainer]: community-roles.md#maintainer
 [core maintainers]: community-roles.md#core-maintainers
+[org admins]: community-roles.md#org-admins
 [community-roles.md]: community-roles.md

--- a/ORG-ADMINS
+++ b/ORG-ADMINS
@@ -1,0 +1,9 @@
+# Flux Org Admins
+
+| Name | Slack handle | GitHub handle | Affiliation |
+| -- | -- | -- | -- |
+| Chris Aniszczyk | `caniszczyk` | `@caniszczyk` | CNCF |
+| Hidde Beydals | `hidde` | `@hiddeco` | Weaveworks  |
+| Stefan Prodan | `stefanprodan` | `@stefanprodan` | Weaveworks  |
+| Michael Bridgen | `Michael Bridgen` | `@squaremo` | Weaveworks  |
+| The Linux Foundation | - | `thelinuxfoundation` | The Linux Foundation |

--- a/OVERSIGHT.md
+++ b/OVERSIGHT.md
@@ -1,7 +1,0 @@
-# Flux Oversight Committee
-
-| Name | Slack handle | GitHub handle | Affiliation |
-| -- | -- | -- | -- |
-| Hidde Beydals | `hidde` | `@hiddeco` | Weaveworks  |
-| Stefan Prodan | `stefanprodan` | `@stefanprodan` | Weaveworks  |
-| Michael Bridgen | `Michael Bridgen` | `@squaremo` | Weaveworks  |

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -52,7 +52,7 @@ As foundational documents such as [GOVERNANCE.md](GOVERNANCE.md) and [community-
     ```
 
 - Have your sponsoring maintainers reply confirmation of sponsorship: `+1`
-- Once your sponsors have responded, your request will be reviewed by a member of the [flux2-maintainers].
+- Once your sponsors have responded, your request will be reviewed by a member of the [core-maintainers].
 
 Any missing information will be requested.
 
@@ -63,7 +63,7 @@ Any missing information will be requested.
 - Make a PR against the `MAINTAINERS` file for a `fluxcd` GitHub org repo. [Example PR](https://github.com/fluxcd/source-controller/pull/584)
 - @mention all the other current maintainers
 - Have maintainers submit their vote by `+1`
-- Once all maintainers in repo have `+1` the pr will be reviewed by a member of the [flux2-maintainers]
+- Once all maintainers in repo have `+1` the pr will be reviewed by a member of the [core-maintainers]
 
 Electing new Maintainers of the same repository is a [Supermajority decision](#supermajority-decisions).
 
@@ -95,7 +95,7 @@ Once the above process has taken its course, make sure you
 It is important for contributors to be and stay active to set an example and show commitment to the project.
 Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
 
-Inactivity is to be defined by the [flux2 maintainers] team.
+Inactivity is to be defined by the [core maintainers] team.
 
 Consequences of being inactive include:
 
@@ -108,27 +108,27 @@ Involuntary removal of a contributor happens when responsibilities and requireme
 This may include repeated pattern of inactivity, extended period of inactivity, and/or a violation of the Code of Conduct.
 This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
 
-Involuntary removal is handled by the [flux2 maintainers] team. Removing a Repository Maintainer or flux2 Maintainer for any reason other than inactivity is a [Supermajority decision](#supermajority-decisions).
+Involuntary removal is handled by the [core maintainers] team. Removing a Repository Maintainer or Core Maintainer for any reason other than inactivity is a [Supermajority decision](#supermajority-decisions).
 
 ### Stepping Down/Emeritus Process
 
 If and when contributors' commitment levels change, contributors can consider stepping down (moving down a role) vs moving to emeritus status (completely stepping away from the project).
 
-Please reach out to the [flux2 maintainers] team to discuss this process.
+Please reach out to the [core maintainers] team to discuss this process.
 
 ### Stepping Back Into a Role
 
-If and when someone is available to step back into a previous contributor role, this is something that can be arranged and considered by the [flux2 maintainers] team.
+If and when someone is available to step back into a previous contributor role, this is something that can be arranged and considered by the [core maintainers] team.
 
-Please reach out to the [flux2 maintainers] team to discuss this process.
+Please reach out to the [core maintainers] team to discuss this process.
 
 ### Licensing changes
 
-Licensing and intellectual property changes is a [Supermajority decision](#supermajority-decisions). To be made by the [flux2 maintainers].
+Licensing and intellectual property changes is a [Supermajority decision](#supermajority-decisions). To be made by the [core maintainers].
 
 ### Governance changes
 
-[flux2 maintainers] decide on material changes to the Governance document.
+[core maintainers] decide on material changes to the Governance document.
  This is a [Supermajority decision](#supermajority-decisions).
 
 - Note: editorial changes to governance may be made by lazy consensus, unless challenged.
@@ -137,7 +137,7 @@ Licensing and intellectual property changes is a [Supermajority decision](#super
 
 ### Contact
 
-For inquiries, please reach out to: `@fluxcd/flux2-maintainers` on GitHub.
+For inquiries, please reach out to: `@fluxcd/core-maintainers` on GitHub.
 
 ### Examples of Decisions
 
@@ -148,4 +148,4 @@ For inquiries, please reach out to: `@fluxcd/flux2-maintainers` on GitHub.
 [Community Member]: community-roles.md#community-member
 [Project Member]: community-roles.md#project-member
 [Maintainer]: community-roles.md#maintainer
-[flux2 maintainers]: community-roles.md#flux2-maintainers
+[core maintainers]: community-roles.md#core-maintainers

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -65,7 +65,7 @@ Any missing information will be requested.
 - Have maintainers submit their vote by `+1`
 - Once all maintainers in repo have `+1` the pr will be reviewed by a member of the [flux2-maintainers]
 
-Electing new Maintainers of the same repository is an Unanimity decision.
+Electing new Maintainers of the same repository is a [Supermajority decision](#supermajority-decisions).
 
 Once the above process has taken its course, make sure you
 
@@ -108,7 +108,7 @@ Involuntary removal of a contributor happens when responsibilities and requireme
 This may include repeated pattern of inactivity, extended period of inactivity, and/or a violation of the Code of Conduct.
 This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
 
-Involuntary removal is handled by the [flux2 maintainers] team. Removing a Repository Maintainer for any reason other than inactivity is an Unanimity decision.
+Involuntary removal is handled by the [flux2 maintainers] team. Removing a Repository Maintainer for any reason other than inactivity is a [Supermajority decision](#supermajority-decisions).
 
 ### Stepping Down/Emeritus Process
 
@@ -124,12 +124,12 @@ Please reach out to the [flux2 maintainers] team to discuss this process.
 
 ### Licensing changes
 
-Licensing and intellectual property changes is a supermajority decision. To be made by the [flux2 maintainers].
+Licensing and intellectual property changes is a [Supermajority decision](#supermajority-decisions). To be made by the [flux2 maintainers].
 
 ### Governance changes
 
 [flux2 maintainers] decide on material changes to the Governance document.
- This is a supermajority decision.
+ This is a [Supermajority decision](#supermajority-decisions).
 
 - Note: editorial changes to governance may be made by lazy consensus, unless challenged.
   These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -108,7 +108,7 @@ Involuntary removal of a contributor happens when responsibilities and requireme
 This may include repeated pattern of inactivity, extended period of inactivity, and/or a violation of the Code of Conduct.
 This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
 
-Involuntary removal is handled by the [flux2 maintainers] team. Removing a Repository Maintainer for any reason other than inactivity is a [Supermajority decision](#supermajority-decisions).
+Involuntary removal is handled by the [flux2 maintainers] team. Removing a Repository Maintainer or flux2 Maintainer for any reason other than inactivity is a [Supermajority decision](#supermajority-decisions).
 
 ### Stepping Down/Emeritus Process
 

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -1,0 +1,160 @@
+# Flux Community Processes
+
+This document defines community processes in the Flux project.
+
+As foundational documents such as [GOVERNANCE.md](GOVERNANCE.md) and [community-roles.md](community-roles.md) grew, we decided to move definition of processes here. Consider this your "how to" with regard to interacting with the Flux community.
+
+## Joining the Flux Project
+
+### Applying for Flux Membership
+
+**Requirements:**
+
+- Have made multiple contributions to the project or community.
+  Contribution may include, but is not limited to:
+  - Authoring or reviewing PRs on GitHub
+  - Filing or commenting on issues on GitHub
+  - Contributing to project or community discussions (for example meetings, Slack, email discussion forums, Stack Overflow)
+- Subscribed to the [flux-dev mailing list](https://lists.cncf.io/g/cncf-flux-dev/join)
+- Actively contributing to 1 or more `fluxcd` GitHub org repos
+- Sponsored by 2 maintainers.
+  **Note the following requirements for sponsors:**
+  - Sponsors must have close interactions with the prospective member - for example code/design/proposal review, coordinating on issues, etc.
+  - Sponsors must be from multiple companies to demonstrate integration across community
+
+**Process:**
+
+[Open an issue against the **fluxcd/community** repo](https://github.com/fluxcd/community/issues/new)
+
+- Ensure your sponsors are @mentioned on the issue
+- Complete every item on the checklist
+
+    ```markdown
+    ### GitHub Username
+    e.g. (at)example_user
+
+    ### Requirements
+    - [ ] I have reviewed the community membership guidelines in `community-roles.md`
+    - [ ] I have subscribed to the cncf-flux-dev e-mail list [https://lists.cncf.io/g/cncf-flux-dev/join](https://lists.cncf.io/g/cncf-flux-dev/join)
+    - [ ] I am actively contributing to 1 or more `fluxcd` GitHub org repos (eg. Flux, Flagger)
+    - [ ] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines
+    - [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application
+
+    ### Sponsors
+    - (at)sponsor-1
+    - (at)sponsor-2
+
+    ### List of contributions to the Flux project
+    - PRs reviewed / authored
+    - Discussions involved in & Issues responded to
+    - Flux subprojects I am involved with (Flagger, Flux, Controllers)
+    ```
+
+- Have your sponsoring maintainers reply confirmation of sponsorship: `+1`
+- Once your sponsors have responded, your request will be reviewed by a member of the [flux2-maintainers].
+
+Any missing information will be requested.
+
+### Applying for Flux Maintainership
+
+**Requirements:**
+
+- Make a PR against the `MAINTAINERS` file for a `fluxcd` GitHub org repo. [Example PR](https://github.com/fluxcd/source-controller/pull/584)
+- @mention all the other current maintainers
+- Have maintainers submit their vote by `+1`
+- Once all maintainers in repo have `+1` the pr will be reviewed by a member of the [flux2-maintainers]
+
+Electing new Maintainers of the same repository is an Unanimity decision.
+
+Once the above process has taken its course, make sure you
+
+- Are added to the internal `#flux-maintainers` Slack channel
+- Update <https://maintainers.cncf.io>
+- Get somebody to ping [CNCF Service Desk](https://cncfservicedesk.atlassian.net/) to get you added as Flux maintainer
+- Ping fellow maintainers to get added to Flux 1Password
+- (Optional) Check if your [CNCF affiliation is up to date](https://github.com/cncf/gitdm#addingupdating-affiliation)
+
+## Proposal Process
+
+- Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with [Maintainers][Maintainer], other contributors, and end users.
+  Pull requests should only be merged after receiving GitHub approval from at least one Maintainer who is not the pull request author.
+- For architectural changes to Flux, please use the [RFC process](https://github.com/fluxcd/flux2/tree/main/rfcs).  
+  Note that Flux v2 uses GitHub discussions for (non-architectural) proposals in the `fluxcd/flux2` Git repository <https://github.com/fluxcd/flux2/discussions?discussions_q=category%3AProposals>.
+- Non-code changes should be proposed as GitHub issues.
+  If unclear which Git repository to create the issue in, default to the community repository <https://github.com/fluxcd/community>.
+- All proposals should be discussed publicly in an appropriate GitHub issue or pull request.
+- If a Maintainer of an affected git repository feels feedback from specific people is warranted they will @mention those users or teams to request feedback.
+- Proposals may also be added to the Flux Dev weekly meetings agenda, as a good avenue for making progress on a decision <https://lists.cncf.io/g/cncf-flux-dev/calendar>.
+
+## Project Processes
+
+### Inactivity
+<!--TODO: project leads to fill in exact details for how you measure inactivity for your project-->
+
+It is important for contributors to be and stay active to set an example and show commitment to the project.
+Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
+
+Inactivity is to be defined by the [flux2 maintainers] team.
+
+Consequences of being inactive include:
+
+- Involuntary Removal
+- Being moved to Emeritus status
+
+### Involuntary Removal
+
+Involuntary removal of a contributor happens when responsibilities and requirements aren't being met.
+This may include repeated pattern of inactivity, extended period of inactivity, and/or a violation of the Code of Conduct.
+This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
+
+Involuntary removal is handled by the [flux2 maintainers] team. Removing a Repository Maintainer for any reason other than inactivity is an Unanimity decision.
+
+### Stepping Down/Emeritus Process
+
+If and when contributors' commitment levels change, contributors can consider stepping down (moving down a role) vs moving to emeritus status (completely stepping away from the project).
+
+Please reach out to the [flux2 maintainers] team to discuss this process.
+
+### Stepping Back Into a Role
+
+If and when someone is available to step back into a previous contributor role, this is something that can be arranged and considered by the [flux2 maintainers] team.
+
+Please reach out to the [flux2 maintainers] team to discuss this process.
+
+### Code of Conduct
+
+The Flux community adheres to the CNCF Code of Conduct <https://github.com/cncf/foundation/blob/master/code-of-conduct.md>.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a _Flux_ [flux2 maintainers] member.
+
+Enforcing a Code of Conduct violation by a community member is a supermajority decision.
+
+If no conclusion can be reached in meditation, such issues can be escalated to the CNCF mediator, Mishi Choudhary <mishi@linux.com>, in which case CNCF may choose to intervene.
+
+### Licensing changes
+
+Licensing and intellectual property changes is a supermajority decision. To be made by the [flux2 maintainers].
+
+### Governance changes
+
+[flux2 maintainers] decide on material changes to the Governance document.
+ This is a supermajority decision.
+
+- Note: editorial changes to governance may be made by lazy consensus, unless challenged.
+  These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.
+  They do not change the intention or meaning of anything in this document.
+
+### Contact
+
+For inquiries, please reach out to: `@fluxcd/flux2-maintainers` on GitHub.
+
+### Examples of Decisions
+
+- Project change: Moving Flagger under the Flux organisation was not a code or architectural change, but a big decision that impacted the Flux project and community, hence it was discussed in various [Flux Dev meetings](https://fluxcd.io/community/#meetings), before being put up at <https://github.com/fluxcd/community/issues/34> for a comment period of one month and when there were no objections, the decision was announced [here](https://fluxcd.io/blog/2021/01/january-2021-update/#flagger-moves-under-the-fluxcd-organization).
+- Architectural change: introducing the RFC process itself was introduced as [an RFC](https://github.com/fluxcd/flux2/pull/2085). Here is a list of other architectural changes which fall under that category: <https://github.com/fluxcd/flux2/pulls?q=label%3Aarea%2FRFC+>.
+- Application to become a member of the Flux project was filed as an issue under `fluxcd/community`: <https://github.com/fluxcd/community/issues/127> (a checklist of requirements, sponsors, list of contributions, and approval can be found in the issue - just follow [this process](community-roles.md#project-member)).
+
+[Community Member]: community-roles.md#community-member
+[Project Member]: community-roles.md#project-member
+[Maintainer]: community-roles.md#maintainer
+[flux2 maintainers]: community-roles.md#flux2-maintainers

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -58,7 +58,7 @@ Any missing information will be requested.
 
 ### Applying for Flux Maintainership
 
-**Requirements:**
+**Process:**
 
 - Make a PR against the `MAINTAINERS` file for a `fluxcd` GitHub org repo. [Example PR](https://github.com/fluxcd/source-controller/pull/584)
 - @mention all the other current maintainers

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -37,6 +37,7 @@ As foundational documents such as [GOVERNANCE.md](GOVERNANCE.md) and [community-
     - [ ] I have reviewed the community membership guidelines in `community-roles.md`
     - [ ] I have subscribed to the cncf-flux-dev e-mail list [https://lists.cncf.io/g/cncf-flux-dev/join](https://lists.cncf.io/g/cncf-flux-dev/join)
     - [ ] I am actively contributing to 1 or more `fluxcd` GitHub org repos (eg. Flux, Flagger)
+    - [ ] I have enabled 2FA in GitHub
     - [ ] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines
     - [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application
 

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -65,7 +65,7 @@ Any missing information will be requested.
 - Have maintainers submit their vote by `+1`
 - Once all maintainers in repo have `+1` the pr will be reviewed by a member of the [core maintainers]
 
-Electing new Maintainers of the same repository is a [Supermajority decision](#supermajority-decisions).
+Electing new Maintainers of the same repository is an [Unanimity decision][unanimity-decisions].
 
 Once the above process has taken its course, make sure you
 
@@ -110,7 +110,7 @@ Involuntary removal of a contributor happens when responsibilities and requireme
 This may include repeated pattern of inactivity, extended period of inactivity, and/or a violation of the Code of Conduct.
 This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
 
-Involuntary removal is handled by the [core maintainers] team. Removing a Repository Maintainer or Core Maintainer for any reason other than inactivity is a [Supermajority decision](#supermajority-decisions).
+Involuntary removal is handled by the [core maintainers] team. Removing a Repository Maintainer or Core Maintainer for any reason other than inactivity is a [Supermajority decision][supermajority-decisions].
 
 ### Stepping Down/Emeritus Process
 
@@ -126,12 +126,12 @@ Please reach out to the [core maintainers] team to discuss this process.
 
 ### Licensing changes
 
-Licensing and intellectual property changes is a [Supermajority decision](#supermajority-decisions). To be made by the [core maintainers].
+Licensing and intellectual property changes is a [Unanimity decision][unanimity-decisions]. To be made by the [core maintainers].
 
 ### Governance changes
 
 [core maintainers] decide on material changes to the Governance document.
- This is a [Supermajority decision](#supermajority-decisions).
+ This is a [Supermajority decision][supermajority-decisions].
 
 - Note: editorial changes to governance may be made by lazy consensus, unless challenged.
   These are changes which fix spelling or grammar, update work affiliation or similar, update style or reflect an outside and obvious reality.
@@ -164,3 +164,5 @@ The list of members is reviewed every year and should consist of:
 [Project Member]: community-roles.md#project-member
 [Maintainer]: community-roles.md#maintainer
 [core maintainers]: community-roles.md#core-maintainers
+[supermajority-decisions]: GOVERNANCE.md#supermajority-decisions
+[unanimity-decisions]: GOVERNANCE.md#unanimity-decisions

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -52,7 +52,7 @@ As foundational documents such as [GOVERNANCE.md](GOVERNANCE.md) and [community-
     ```
 
 - Have your sponsoring maintainers reply confirmation of sponsorship: `+1`
-- Once your sponsors have responded, your request will be reviewed by a member of the [core-maintainers].
+- Once your sponsors have responded, your request will be reviewed by a member of the [core maintainers].
 
 Any missing information will be requested.
 
@@ -63,7 +63,7 @@ Any missing information will be requested.
 - Make a PR against the `MAINTAINERS` file for a `fluxcd` GitHub org repo. [Example PR](https://github.com/fluxcd/source-controller/pull/584)
 - @mention all the other current maintainers
 - Have maintainers submit their vote by `+1`
-- Once all maintainers in repo have `+1` the pr will be reviewed by a member of the [core-maintainers]
+- Once all maintainers in repo have `+1` the pr will be reviewed by a member of the [core maintainers]
 
 Electing new Maintainers of the same repository is a [Supermajority decision](#supermajority-decisions).
 
@@ -74,6 +74,8 @@ Once the above process has taken its course, make sure you
 - Get somebody to ping [CNCF Service Desk](https://cncfservicedesk.atlassian.net/) to get you added as Flux maintainer
 - Ping fellow maintainers to get added to Flux 1Password
 - (Optional) Check if your [CNCF affiliation is up to date](https://github.com/cncf/gitdm#addingupdating-affiliation)
+
+**Applying as core maintainer:** The same process applies for applying as a core maintainer. The PR should be against the [CORE-MAINTAINERS file](https://github.com/fluxcd/community/blob/main/CORE-MAINTAINERS) though and an accordingly higher level of experience and a more holistic understanding of the project is expected.
 
 ## Proposal Process
 

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -139,6 +139,19 @@ Licensing and intellectual property changes is a [Supermajority decision](#super
 
 For inquiries, please reach out to: `@fluxcd/core-maintainers` on GitHub.
 
+### Requesting new repositories / bots / GitHub applications / etc
+
+File an issue in the `fluxcd/community` repository and contact the `@fluxcd/org-admins` team to fulfil your request.
+
+### Electing Org Admins
+
+Org Admins are defined in the [ORG-ADMINS file](https://github.com/fluxcd/community/blob/main/ORG-ADMINS). An election can be done through a pull request against this file to be approved by the [core maintainers].
+
+The list of members is reviewed every year and should consist of:
+
+- active members (preferably spread over various timezones and organizations)
+- counterparts at the CNCF and Linux Foundation
+
 ### Examples of Decisions
 
 - Project change: Moving Flagger under the Flux organisation was not a code or architectural change, but a big decision that impacted the Flux project and community, hence it was discussed in various [Flux Dev meetings](https://fluxcd.io/community/#meetings), before being put up at <https://github.com/fluxcd/community/issues/34> for a comment period of one month and when there were no objections, the decision was announced [here](https://fluxcd.io/blog/2021/01/january-2021-update/#flagger-moves-under-the-fluxcd-organization).

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -122,16 +122,6 @@ If and when someone is available to step back into a previous contributor role, 
 
 Please reach out to the [flux2 maintainers] team to discuss this process.
 
-### Code of Conduct
-
-The Flux community adheres to the CNCF Code of Conduct <https://github.com/cncf/foundation/blob/master/code-of-conduct.md>.
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a _Flux_ [flux2 maintainers] member.
-
-Enforcing a Code of Conduct violation by a community member is a supermajority decision.
-
-If no conclusion can be reached in meditation, such issues can be escalated to the CNCF mediator, Mishi Choudhary <mishi@linux.com>, in which case CNCF may choose to intervene.
-
 ### Licensing changes
 
 Licensing and intellectual property changes is a supermajority decision. To be made by the [flux2 maintainers].

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -86,7 +86,7 @@ Once the above process has taken its course, make sure you
 - Non-code changes should be proposed as GitHub issues.
   If unclear which Git repository to create the issue in, default to the community repository <https://github.com/fluxcd/community>.
 - All proposals should be discussed publicly in an appropriate GitHub issue or pull request.
-- If a Maintainer of an affected git repository feels feedback from specific people is warranted they will @mention those users or teams to request feedback.
+- If a Maintainer of an affected Git repository feels feedback from specific people is warranted they will @mention those users or teams to request feedback.
 - Proposals may also be added to the Flux Dev weekly meetings agenda, as a good avenue for making progress on a decision <https://lists.cncf.io/g/cncf-flux-dev/calendar>.
 
 ## Project Processes

--- a/README.md
+++ b/README.md
@@ -101,5 +101,5 @@ See [project/flux-project-maintainers.yaml](./project/flux-project-maintainers.y
 
 ## Rules
 
-The Flux community is governed by the [governance document](GOVERNANCE.md), and involvement is defined in [community-roles.md](community-roles.md).
+The Flux community is governed by the [governance document](GOVERNANCE.md), involvement is defined in [community-roles.md](community-roles.md), and processes can be found in [PROCESS.md](PROCESS.md).
 We as a community follow the [code of conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See [community-roles.md](community-roles.md).
 The process of formalising team structures apart from "interest in one or more given sub-project(s)" is ongoing.
 There currently are:
 
-- The [Oversight committee](GOVERNANCE.md#oversight-committee)
+- The [flux2 maintainers](GOVERNANCE.md#flux2-maintainers)
 - The [Security team](SECURITY.md)
 - The [Community team](COMMUNITY.md)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Afterwards you can help out on Slack answering questions, maybe extend the docs 
 
 ### Teams
 
-The Flux project uses [GitHub org teams](https://docs.github.com/en/organizations) to make it easier for [Project Members](community-roles.md#project-members) and above to communicate within and across teams.
+The Flux project uses [GitHub org teams](https://docs.github.com/en/organizations) to make it easier for [Project Members](community-roles.md#project-member) and above to communicate within and across teams.
 Members of those teams however should be defined in publicly accessible files for transparency to org non-members.
 See [community-roles.md](community-roles.md).
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See [community-roles.md](community-roles.md).
 The process of formalising team structures apart from "interest in one or more given sub-project(s)" is ongoing.
 There currently are:
 
-- The [flux2 maintainers](GOVERNANCE.md#flux2-maintainers)
+- The [core maintainers](GOVERNANCE.md#core-maintainers)
 - The [Security team](SECURITY.md)
 - The [Community team](COMMUNITY.md)
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -111,7 +111,7 @@ Luckily some of the companies who employ Flux developers offer paid support, so 
 
 ---
 
-*Flux is a CNCF project, so this "paid support" section is not tied to any single company in particular. If you want to add your company to the list, please file a PR and tag the [Flux Oversight Committee](https://github.com/fluxcd/community/blob/main/GOVERNANCE.md#oversight-committee).*
+*Flux is a CNCF project, so this "paid support" section is not tied to any single company in particular. If you want to add your company to the list, please file a PR and tag the [flux 2 Maintainers](https://github.com/fluxcd/community/blob/main/GOVERNANCE.md#flux2-maintainers).*
 
 *If your company has a track record of Flux engineering and/or support we will get you added.*
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -111,7 +111,7 @@ Luckily some of the companies who employ Flux developers offer paid support, so 
 
 ---
 
-*Flux is a CNCF project, so this "paid support" section is not tied to any single company in particular. If you want to add your company to the list, please file a PR and tag the [flux 2 Maintainers](https://github.com/fluxcd/community/blob/main/GOVERNANCE.md#flux2-maintainers).*
+*Flux is a CNCF project, so this "paid support" section is not tied to any single company in particular. If you want to add your company to the list, please file a PR and tag the [Core Maintainers](https://github.com/fluxcd/community/blob/main/GOVERNANCE.md#core-maintainers).*
 
 *If your company has a track record of Flux engineering and/or support we will get you added.*
 

--- a/community-roles.md
+++ b/community-roles.md
@@ -87,7 +87,7 @@ Process: refer to [PROCESS.md](PROCESS.md#applying-for-flux-maintainership).
 
 ### Core maintainers
 
-Maintainership in the [flux2 MAINTAINERS file](https://github.com/fluxcd/flux2/blob/main/MAINTAINERS) trickles down to all other Flux 2-related repositories which means that maintainers mentioned there are also maintainers in all other repositories.
+Maintainership in the [CORE-MAINTAINERS file](https://github.com/fluxcd/community/blob/main/CORE-MAINTAINERS) trickles down to all other Flux 2-related repositories which means that maintainers mentioned there are also maintainers in all other repositories.
 
 In addition to maintaining `flux2` and Flux 2-related repositories, this team serves as escalation point for the overall project, and anything not easily managed by the Maintainers of each git repository.
 
@@ -96,7 +96,7 @@ This team drives the direction, values and governance of the overall project.
 It is important to us that its members come from a diverse background of companies and organizations.
 Ensuring that oversight of the project is not controlled by one company or organization.
 
-**Defined by:** entry in [flux2 MAINTAINERS file](https://github.com/fluxcd/flux2/blob/main/MAINTAINERS), and in the `@fluxcd/core-maintainers` GitHub team.
+**Defined by:** entry in [CORE-MAINTAINERS file](https://github.com/fluxcd/community/blob/main/CORE-MAINTAINERS), and in the `@fluxcd/core-maintainers` GitHub team.
 
 **Responsibilities and Privileges:**
 

--- a/community-roles.md
+++ b/community-roles.md
@@ -21,10 +21,10 @@ Roles are progressive, so each include responsibilities, requirements and defini
 
 Most of the roles defined herein are defined by membership in a certain GitHub organization or team:
 
-* [fluxcd org](https://github.com/fluxcd): The organization under which all of Flux's activity on GitHub is captured.
-* [@fluxcd/flux2-maintainers](https://github.com/orgs/fluxcd/teams/flux2-maintainers): The team comprised of all maintainers of Flux v2 components.
-* [@fluxcd/maintainers](https://github.com/orgs/fluxcd/teams/maintainers): The team comprised of all maintainers of both, Flux v1 and Flux v2 components.
-* [@fluxcd/oversight-committee](https://github.com/orgs/fluxcd/teams/oversight-committee): The team comprised of all [Oversight Committee] members.
+- [fluxcd org](https://github.com/fluxcd): The organization under which all of Flux's activity on GitHub is captured.
+- [@fluxcd/flux2-maintainers](https://github.com/orgs/fluxcd/teams/flux2-maintainers): The team comprised of all maintainers of Flux v2 components.
+- [@fluxcd/maintainers](https://github.com/orgs/fluxcd/teams/maintainers): The team comprised of all maintainers of both, Flux v1 and Flux v2 components.
+- [@fluxcd/oversight-committee](https://github.com/orgs/fluxcd/teams/oversight-committee): The team comprised of all [Oversight Committee] members.
 
 ### Community Member
 

--- a/community-roles.md
+++ b/community-roles.md
@@ -58,7 +58,7 @@ Process: refer to [PROCESS.md](PROCESS.md#applying-for-flux-membership).
 
 ### Maintainer
 
-Maintainers are elected [Project Members][Project Member] who have shown significant and sustained contributions in a git repository.
+Maintainers are elected [Project Members][Project Member] who have shown significant and sustained contributions in a Git repository.
 
 **Defined by:** entry in MAINTAINERS file in a repo owned by the Flux project, and membership in the [@fluxcd/maintainers](https://github.com/orgs/fluxcd/teams/maintainers) GitHub team.
 
@@ -68,14 +68,14 @@ To become a Maintainer you need to demonstrate the following:
 
 - Enable and promote Flux community values
 - Engage with end Users through appropriate communication channels
-- Serve as a point of conflict resolution between Contributors to their git repository
+- Serve as a point of conflict resolution between Contributors to their Git repository
 - Maintain open collaboration with Contributors and other Maintainers
 - Ask for help when unsure and step down considerately
 - A good understanding of the code-base (or equivalent that is governed by the repository, e.g. `fluxcd/community` or `fluxcd/website`)
 - Willing to take on long-term responsibility for the project (or a specific part of it)
 - Commitment to the project. Specifically:
 
-  This can be evidenced differently and we want to maintain some general flexibility assessing this. Significant and sustained contributions can be be both by showing a long-term level of care with a bigger number of smaller contributions or by a smaller set of sizable contributions. To make it somewhat more comparable, here is an example of commitment we would be happy to accept for a maintainer:
+  This can be evidenced differently and we want to maintain some general flexibility assessing this. Significant and sustained contributions can be both by showing a long-term level of care with a bigger number of smaller contributions or by a smaller set of sizable contributions. To make it somewhat more comparable, here is an example of commitment we would be happy to accept for a maintainer:
 
   - Participate in discussions, contributions, code and documentation reviews for 3 months or more,
   - perform reviews for 10 non-trivial pull requests (total),
@@ -89,7 +89,7 @@ Process: refer to [PROCESS.md](PROCESS.md#applying-for-flux-maintainership).
 
 Maintainership in the [CORE-MAINTAINERS file](https://github.com/fluxcd/community/blob/main/CORE-MAINTAINERS) trickles down to all other Flux 2-related repositories which means that maintainers mentioned there are also maintainers in all other repositories.
 
-In addition to maintaining `flux2` and Flux 2-related repositories, this team serves as escalation point for the overall project, and anything not easily managed by the Maintainers of each git repository.
+In addition to maintaining `flux2` and Flux 2-related repositories, this team serves as escalation point for the overall project, and anything not easily managed by the Maintainers of each Git repository.
 
 This team drives the direction, values and governance of the overall project.
 
@@ -106,10 +106,10 @@ The following apply to all assets across the Flux org:
 - Maintaining the brand, mission, vision, values, and scope of the overall project
 - Changes to licensing and intellectual property
 - Administering access to all project assets
-- Administering git repositories as needed
+- Administering Git repositories as needed
 - Handling Code of Conduct violations
 - Managing financial decisions
-- Defining the scope of each git repository
+- Defining the scope of each Git repository
 - Resolving escalated decisions when Maintainers responsible are blocked
 
 ### Org Admins

--- a/community-roles.md
+++ b/community-roles.md
@@ -10,12 +10,6 @@ Roles are progressive, so each include responsibilities, requirements and defini
   - [Project Member](#project-member)
   - [Maintainer](#maintainer)
   - [flux2 maintainers](#flux2-maintainers)
-- [Processes](#processes)
-  - [Inactivity](#inactivity)
-  - [Involuntary Removal](#involuntary-removal)
-  - [Stepping Down/Emeritus Process](#stepping-downemeritus-process)
-  - [Stepping Back Into a Role](#stepping-back-into-a-role)
-  - [Contact](#contact)
 
 ## Roles
 
@@ -45,48 +39,6 @@ This can be through code, documentation, taking part in bug scrubs, etc.
 - [Triage role](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization#repository-access-for-each-permission-level) on all `fluxcd` GitHub org repos
 - [Membership](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-user-account/managing-your-membership-in-organizations/about-organization-membership) in the [fluxcd org](https://github.com/fluxcd)
 
-**Requirements:**
-
-- Have made multiple contributions to the project or community.
-  Contribution may include, but is not limited to:
-  - Authoring or reviewing PRs on GitHub
-  - Filing or commenting on issues on GitHub
-  - Contributing to project or community discussions (for example meetings, Slack, email discussion forums, Stack Overflow)
-- Subscribed to the [flux-dev mailing list](https://lists.cncf.io/g/cncf-flux-dev/join)
-- Actively contributing to 1 or more `fluxcd` GitHub org repos
-- Sponsored by 2 maintainers.
-  **Note the following requirements for sponsors:**
-  - Sponsors must have close interactions with the prospective member - for example code/design/proposal review, coordinating on issues, etc.
-  - Sponsors must be from multiple companies to demonstrate integration across community
-- [Open an issue against the **fluxcd/community** repo](https://github.com/fluxcd/community/issues/new)
-  - Ensure your sponsors are @mentioned on the issue
-  - Complete every item on the checklist
-
-    ```markdown
-    ### GitHub Username
-    e.g. (at)example_user
-
-    ### Requirements
-    - [ ] I have reviewed the community membership guidelines in `community-roles.md`
-    - [ ] I have subscribed to the cncf-flux-dev e-mail list [https://lists.cncf.io/g/cncf-flux-dev/join](https://lists.cncf.io/g/cncf-flux-dev/join)
-    - [ ] I am actively contributing to 1 or more `fluxcd` GitHub org repos (eg. Flux, Flagger)
-    - [ ] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines
-    - [ ] I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application
-
-    ### Sponsors
-    - (at)sponsor-1
-    - (at)sponsor-2
-
-    ### List of contributions to the Flux project
-    - PRs reviewed / authored
-    - Discussions involved in & Issues responded to
-    - Flux subprojects I am involved with (Flagger, Flux, Controllers)
-    ```
-
-  - Have your sponsoring maintainers reply confirmation of sponsorship: `+1`
-  - Once your sponsors have responded, your request will be reviewed by a member of the [flux2-maintainers].
-    Any missing information will be requested.
-
 **Responsibilities and privileges:**
 
 - Responsive to issues and PRs assigned to them
@@ -96,26 +48,13 @@ This can be through code, documentation, taking part in bug scrubs, etc.
   - Addresses bugs or issues discovered after code is accepted
 - Note: members who frequently contribute code are expected to proactively perform code reviews and work towards becoming a maintainer
 
+Process: refer to [PROCESS.md](PROCESS.md#applying-for-flux-membership).
+
 ### Maintainer
 
 Maintainers are elected [Project Members][Project Member] who have shown significant and sustained contributions in a git repository.
 
 **Defined by:** entry in MAINTAINERS file in a repo owned by the Flux project, and membership in the [@fluxcd/maintainers](https://github.com/orgs/fluxcd/teams/maintainers) GitHub team.
-
-**Requirements:**
-
-- Make a PR against the `MAINTAINERS` file for a `fluxcd` GitHub org repo. [Example PR](https://github.com/fluxcd/source-controller/pull/584)
-- @mention all the other current maintainers
-- Have maintainers submit their vote by `+1`
-- Once all maintainers in repo have `+1` the pr will be reviewed by a member of the [flux2-maintainers]
-
-Once the above process has taken its course, make sure you
-
-- Are added to the internal `#flux-maintainers` Slack channel
-- Update <https://maintainers.cncf.io>
-- Get somebody to ping [CNCF Service Desk](https://cncfservicedesk.atlassian.net/) to get you added as Flux maintainer
-- Ping fellow maintainers to get added to Flux 1Password
-- (Optional) Check if your [CNCF affiliation is up to date](https://github.com/cncf/gitdm#addingupdating-affiliation)
 
 **Responsibilities and Privileges:**
 
@@ -126,6 +65,8 @@ The following apply to the part of the codebase for which one would be in a MAIN
 - Serve as a point of conflict resolution between Contributors to their git repository
 - Maintain open collaboration with Contributors and other Maintainers
 - Ask for help when unsure and step down considerately
+
+Process: refer to [PROCESS.md](PROCESS.md#applying-for-flux-maintainership).
 
 ### flux2 maintainers
 
@@ -153,51 +94,6 @@ The following apply to all assets across the Flux org:
 - Managing financial decisions
 - Defining the scope of each git repository
 - Resolving escalated decisions when Maintainers responsible are blocked
-
-## Processes
-
-### Inactivity
-<!--TODO: project leads to fill in exact details for how you measure inactivity for your project-->
-
-It is important for contributors to be and stay active to set an example and show commitment to the project.
-Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
-
-Inactivity is to be defined by the [flux2 maintainers] team.
-
-Consequences of being inactive include:
-
-- Involuntary Removal
-- Being moved to Emeritus status
-
-### Involuntary Removal
-
-Involuntary removal of a contributor happens when responsibilities and requirements aren't being met.
-This may include repeated pattern of inactivity, extended period of inactivity, and/or a violation of the Code of Conduct.
-This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
-
-Involuntary removal is handled by the [flux2 maintainers] team.
-
-### Stepping Down/Emeritus Process
-
-If and when contributors' commitment levels change, contributors can consider stepping down (moving down a role) vs moving to emeritus status (completely stepping away from the project).
-
-Please reach out to the [flux2 maintainers] team to discuss this process.
-
-### Stepping Back Into a Role
-
-If and when someone is available to step back into a previous contributor role, this is something that can be arranged and considered by the [flux2 maintainers] team.
-
-Please reach out to the [flux2 maintainers] team to discuss this process.
-
-### Contact
-
-For inquiries, please reach out to: `@fluxcd/flux2-maintainers` on GitHub.
-
-### Examples of Decisions
-
-- Project change: Moving Flagger under the Flux organisation was not a code or architectural change, but a big decision that impacted the Flux project and community, hence it was discussed in various [Flux Dev meetings](https://fluxcd.io/community/#meetings), before being put up at <https://github.com/fluxcd/community/issues/34> for a comment period of one month and when there were no objections, the decision was announced [here](https://fluxcd.io/blog/2021/01/january-2021-update/#flagger-moves-under-the-fluxcd-organization).
-- Architectural change: introducing the RFC process itself was introduced as [an RFC](https://github.com/fluxcd/flux2/pull/2085). Here is a list of other architectural changes which fall under that category: <https://github.com/fluxcd/flux2/pulls?q=label%3Aarea%2FRFC+>.
-- Application to become a member of the Flux project was filed as an issue under `fluxcd/community`: <https://github.com/fluxcd/community/issues/127> (a checklist of requirements, sponsors, list of contributions, and approval can be found in the issue - just follow [this process](#project-member)).
 
 <!-- md links -->
 [Community Member]: #community-member

--- a/community-roles.md
+++ b/community-roles.md
@@ -9,14 +9,14 @@ Roles are progressive, so each include responsibilities, requirements and defini
   - [Community Member](#community-member)
   - [Project Member](#project-member)
   - [Maintainer](#maintainer)
-  - [flux2 maintainers](#flux2-maintainers)
+  - [Core maintainers](#core-maintainers)
 
 ## Roles
 
 Most of the roles defined herein are defined by membership in a certain GitHub organization or team:
 
 - [fluxcd org](https://github.com/fluxcd): The organization under which all of Flux's activity on GitHub is captured.
-- [@fluxcd/flux2-maintainers](https://github.com/orgs/fluxcd/teams/flux2-maintainers): The team comprised of all maintainers of Flux v2 components.
+- [@fluxcd/core-maintainers](https://github.com/orgs/fluxcd/teams/core-maintainers): The team comprised of all maintainers of Flux v2 components.
 - [@fluxcd/maintainers](https://github.com/orgs/fluxcd/teams/maintainers): The team comprised of all maintainers of the various projects in the FluxCD organisation: Flux v1, Flux v2, Flagger, GitOps Toolkit, website and community repos, etc.
 
 ### Community Member
@@ -85,9 +85,9 @@ To become a Maintainer you need to demonstrate the following:
 
 Process: refer to [PROCESS.md](PROCESS.md#applying-for-flux-maintainership).
 
-### flux2 maintainers
+### Core maintainers
 
-Maintainership in the [flux2 MAINTAINERS file](https://github.com/fluxcd/flux2/blob/main/MAINTAINERS) trickles down to all other Flux 2-related repositories which means that mantainers mentioned there are also maintainers in all other repositories.
+Maintainership in the [flux2 MAINTAINERS file](https://github.com/fluxcd/flux2/blob/main/MAINTAINERS) trickles down to all other Flux 2-related repositories which means that maintainers mentioned there are also maintainers in all other repositories.
 
 In addition to maintaining `flux2` and Flux 2-related repositories, this team serves as escalation point for the overall project, and anything not easily managed by the Maintainers of each git repository.
 
@@ -96,7 +96,7 @@ This team drives the direction, values and governance of the overall project.
 It is important to us that its members come from a diverse background of companies and organizations.
 Ensuring that oversight of the project is not controlled by one company or organization.
 
-**Defined by:** entry in [flux2 MAINTAINERS file](https://github.com/fluxcd/flux2/blob/main/MAINTAINERS), and in the `@fluxcd/flux2-maintainers` GitHub team.
+**Defined by:** entry in [flux2 MAINTAINERS file](https://github.com/fluxcd/flux2/blob/main/MAINTAINERS), and in the `@fluxcd/core-maintainers` GitHub team.
 
 **Responsibilities and Privileges:**
 
@@ -116,4 +116,4 @@ The following apply to all assets across the Flux org:
 [Community Member]: #community-member
 [Project Member]: #project-member
 [Maintainer]: #maintainer
-[flux2 maintainers]: #flux2-maintainers
+[core maintainers]: #core-maintainers

--- a/community-roles.md
+++ b/community-roles.md
@@ -9,7 +9,7 @@ Roles are progressive, so each include responsibilities, requirements and defini
   - [Community Member](#community-member)
   - [Project Member](#project-member)
   - [Maintainer](#maintainer)
-  - [Oversight Committee](#oversight-committee)
+  - [flux2 maintainers](#flux2-maintainers)
 - [Processes](#processes)
   - [Inactivity](#inactivity)
   - [Involuntary Removal](#involuntary-removal)
@@ -23,8 +23,7 @@ Most of the roles defined herein are defined by membership in a certain GitHub o
 
 - [fluxcd org](https://github.com/fluxcd): The organization under which all of Flux's activity on GitHub is captured.
 - [@fluxcd/flux2-maintainers](https://github.com/orgs/fluxcd/teams/flux2-maintainers): The team comprised of all maintainers of Flux v2 components.
-- [@fluxcd/maintainers](https://github.com/orgs/fluxcd/teams/maintainers): The team comprised of all maintainers of both, Flux v1 and Flux v2 components.
-- [@fluxcd/oversight-committee](https://github.com/orgs/fluxcd/teams/oversight-committee): The team comprised of all [Oversight Committee] members.
+- [@fluxcd/maintainers](https://github.com/orgs/fluxcd/teams/maintainers): The team comprised of all maintainers of the various projects in the FluxCD organisation: Flux v1, Flux v2, Flagger, GitOps Toolkit, etc.
 
 ### Community Member
 
@@ -85,7 +84,7 @@ This can be through code, documentation, taking part in bug scrubs, etc.
     ```
 
   - Have your sponsoring maintainers reply confirmation of sponsorship: `+1`
-  - Once your sponsors have responded, your request will be reviewed by a member of the Flux [Oversight Committee].
+  - Once your sponsors have responded, your request will be reviewed by a member of the [flux2-maintainers].
     Any missing information will be requested.
 
 **Responsibilities and privileges:**
@@ -101,16 +100,14 @@ This can be through code, documentation, taking part in bug scrubs, etc.
 
 Maintainers are elected [Project Members][Project Member] who have shown significant and sustained contributions in a git repository.
 
-**Defined by:** entry in MAINTAINERS file in a repo owned by the Flux project, and membership in the [@fluxcd/flux2-maintainers](https://github.com/orgs/fluxcd/teams/flux2-maintainers) [@fluxcd/maintainers](https://github.com/orgs/fluxcd/teams/maintainers) GitHub team.
+**Defined by:** entry in MAINTAINERS file in a repo owned by the Flux project, and membership in the [@fluxcd/maintainers](https://github.com/orgs/fluxcd/teams/maintainers) GitHub team.
 
 **Requirements:**
 
 - Make a PR against the `MAINTAINERS` file for a `fluxcd` GitHub org repo. [Example PR](https://github.com/fluxcd/source-controller/pull/584)
 - @mention all the other current maintainers
 - Have maintainers submit their vote by `+1`
-- Once all maintainers in repo have `+1` the pr will be reviewed by a member of the Flux [Oversight Committee]
-
-**flux2 maintainers:** Maintainership in the [flux2 MAINTAINERS file](https://github.com/fluxcd/flux2/blob/main/MAINTAINERS) trickles down to all other Flux 2-related repositories which means that mantainers mentioned there are also maintainers in all other repositories.
+- Once all maintainers in repo have `+1` the pr will be reviewed by a member of the [flux2-maintainers]
 
 Once the above process has taken its course, make sure you
 
@@ -130,23 +127,18 @@ The following apply to the part of the codebase for which one would be in a MAIN
 - Maintain open collaboration with Contributors and other Maintainers
 - Ask for help when unsure and step down considerately
 
-### Oversight Committee
+### flux2 maintainers
 
-The Oversight Committee is responsible for the overall project, and anything not easily managed by the Maintainers of each git repository.
+Maintainership in the [flux2 MAINTAINERS file](https://github.com/fluxcd/flux2/blob/main/MAINTAINERS) trickles down to all other Flux 2-related repositories which means that mantainers mentioned there are also maintainers in all other repositories.
 
-The committee drives the direction, values and governance of the overall project.
+In addition to maintaining `flux2` and Flux 2-related repositories, this team serves as escalation point for the overall project, and anything not easily managed by the Maintainers of each git repository.
 
-The committee is currently comprised of Flux Maintainers who have steered the project prior to the initial Governance document.
+This team drives the direction, values and governance of the overall project.
 
-In future, Committee Members will come from a diverse background of companies and organizations.
+It is important to us that its members come from a diverse background of companies and organizations.
 Ensuring that oversight of the project is not controlled by one company or organization.
 
-**Defined by:** entry in `OVERSIGHT.md` file in the fluxcd/community repo, and in  `@fluxcd/oversight-committee` GitHub team.
-
-**Requirements:**
-
-We aim to build out requirements for the Oversight Committee role during incubation.
-See [fluxcd/community#106](https://github.com/fluxcd/community/issues/106).
+**Defined by:** entry in [flux2 MAINTAINERS file](https://github.com/fluxcd/flux2/blob/main/MAINTAINERS), and in the `@fluxcd/flux2-maintainers` GitHub team.
 
 **Responsibilities and Privileges:**
 
@@ -170,7 +162,7 @@ The following apply to all assets across the Flux org:
 It is important for contributors to be and stay active to set an example and show commitment to the project.
 Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
 
-Inactivity is to be defined by the [Oversight Committee].
+Inactivity is to be defined by the [flux2 maintainers] team.
 
 Consequences of being inactive include:
 
@@ -183,23 +175,23 @@ Involuntary removal of a contributor happens when responsibilities and requireme
 This may include repeated pattern of inactivity, extended period of inactivity, and/or a violation of the Code of Conduct.
 This process is important because it protects the community and its deliverables while also opens up opportunities for new contributors to step in.
 
-Involuntary removal is handled by the [Oversight Committee].
+Involuntary removal is handled by the [flux2 maintainers] team.
 
 ### Stepping Down/Emeritus Process
 
 If and when contributors' commitment levels change, contributors can consider stepping down (moving down a role) vs moving to emeritus status (completely stepping away from the project).
 
-Please reach out to the [Oversight Committee] to discuss this process.
+Please reach out to the [flux2 maintainers] team to discuss this process.
 
 ### Stepping Back Into a Role
 
-If and when someone is available to step back into a previous contributor role, this is something that can be arranged and considered by the project [Oversight Committee].
+If and when someone is available to step back into a previous contributor role, this is something that can be arranged and considered by the [flux2 maintainers] team.
 
-Please reach out to the [Oversight Committee] to discuss this process.
+Please reach out to the [flux2 maintainers] team to discuss this process.
 
 ### Contact
 
-For inquiries, please reach out to: <cncf-flux-oversight-committee@lists.cncf.io>
+For inquiries, please reach out to: `@fluxcd/flux2-maintainers` on GitHub.
 
 ### Examples of Decisions
 
@@ -211,4 +203,4 @@ For inquiries, please reach out to: <cncf-flux-oversight-committee@lists.cncf.io
 [Community Member]: #community-member
 [Project Member]: #project-member
 [Maintainer]: #maintainer
-[Oversight Committee]: #oversight-committee
+[flux2 maintainers]: #flux2-maintainers

--- a/community-roles.md
+++ b/community-roles.md
@@ -41,8 +41,14 @@ This can be through code, documentation, taking part in bug scrubs, etc.
 
 **Responsibilities and privileges:**
 
-- Responsive to issues and PRs assigned to them
-- Active owner of code they have contributed (unless ownership is explicitly transferred)
+To become a Project Member you need to demonstrate the following:
+
+- ability to write quality code and/or documentation,
+- ability to collaborate with the team,
+- understanding of how the team works (policies, processes for testing and code review, etc),
+- understanding of the project's code base and coding and documentation style.
+- be responsive to issues and PRs assigned to them
+- be active owner of code they have contributed (unless ownership is explicitly transferred)
   - Code is well tested
   - Tests consistently pass
   - Addresses bugs or issues discovered after code is accepted
@@ -58,13 +64,17 @@ Maintainers are elected [Project Members][Project Member] who have shown signifi
 
 **Responsibilities and Privileges:**
 
-The following apply to the part of the codebase for which one would be in a MAINTAINERS file:
+To become a Maintainer you need to demonstrate the following:
 
 - Enable and promote Flux community values
 - Engage with end Users through appropriate communication channels
 - Serve as a point of conflict resolution between Contributors to their git repository
 - Maintain open collaboration with Contributors and other Maintainers
 - Ask for help when unsure and step down considerately
+- Commitment to the project:
+  - Participate in discussions, contributions, code and documentation reviews for 3 months or more,
+  - perform reviews for 5 non-trivial pull requests,
+  - contribute 10 non-trivial pull requests and have them merged,
 
 Process: refer to [PROCESS.md](PROCESS.md#applying-for-flux-maintainership).
 

--- a/community-roles.md
+++ b/community-roles.md
@@ -17,7 +17,7 @@ Most of the roles defined herein are defined by membership in a certain GitHub o
 
 - [fluxcd org](https://github.com/fluxcd): The organization under which all of Flux's activity on GitHub is captured.
 - [@fluxcd/flux2-maintainers](https://github.com/orgs/fluxcd/teams/flux2-maintainers): The team comprised of all maintainers of Flux v2 components.
-- [@fluxcd/maintainers](https://github.com/orgs/fluxcd/teams/maintainers): The team comprised of all maintainers of the various projects in the FluxCD organisation: Flux v1, Flux v2, Flagger, GitOps Toolkit, etc.
+- [@fluxcd/maintainers](https://github.com/orgs/fluxcd/teams/maintainers): The team comprised of all maintainers of the various projects in the FluxCD organisation: Flux v1, Flux v2, Flagger, GitOps Toolkit, website and community repos, etc.
 
 ### Community Member
 

--- a/community-roles.md
+++ b/community-roles.md
@@ -71,10 +71,17 @@ To become a Maintainer you need to demonstrate the following:
 - Serve as a point of conflict resolution between Contributors to their git repository
 - Maintain open collaboration with Contributors and other Maintainers
 - Ask for help when unsure and step down considerately
-- Commitment to the project:
+- A good understanding of the code-base (or equivalent that is governed by the repository, e.g. `fluxcd/community` or `fluxcd/website`)
+- Willing to take on long-term responsibility for the project (or a specific part of it)
+- Commitment to the project. Specifically:
+
+  This can be evidenced differently and we want to maintain some general flexibility assessing this. Significant and sustained contributions can be be both by showing a long-term level of care with a bigger number of smaller contributions or by a smaller set of sizable contributions. To make it somewhat more comparable, here is an example of commitment we would be happy to accept for a maintainer:
+
   - Participate in discussions, contributions, code and documentation reviews for 3 months or more,
-  - perform reviews for 5 non-trivial pull requests,
-  - contribute 10 non-trivial pull requests and have them merged,
+  - perform reviews for 10 non-trivial pull requests (total),
+  - contribute 15 non-trivial pull requests (total) and have them merged.
+
+  Ask one of the current maintainers, if you are unsure. They will be happy to give you feedback.
 
 Process: refer to [PROCESS.md](PROCESS.md#applying-for-flux-maintainership).
 

--- a/community-roles.md
+++ b/community-roles.md
@@ -17,7 +17,7 @@ Most of the roles defined herein are defined by membership in a certain GitHub o
 
 - [fluxcd org](https://github.com/fluxcd): The organization under which all of Flux's activity on GitHub is captured.
 - [@fluxcd/core-maintainers](https://github.com/orgs/fluxcd/teams/core-maintainers): The team comprised of all maintainers of Flux v2 components.
-- [@fluxcd/maintainers](https://github.com/orgs/fluxcd/teams/maintainers): The team comprised of all maintainers of the various projects in the FluxCD organisation: Flux v1, Flux v2, Flagger, GitOps Toolkit, website and community repos, etc.
+- [@fluxcd/maintainers](https://github.com/orgs/fluxcd/teams/maintainers): The team comprised of all maintainers of the various projects in the FluxCD organization: Flux v1, Flux v2, Flagger, GitOps Toolkit, website and community repos, etc.
 
 ### Community Member
 
@@ -112,8 +112,26 @@ The following apply to all assets across the Flux org:
 - Defining the scope of each git repository
 - Resolving escalated decisions when Maintainers responsible are blocked
 
+### Org Admins
+
+In order to restrict access to [`admin` level functionality in GitHub](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization#permissions-for-each-role) functionality, we define this team, who can e.g.
+
+- Delete a repository
+- Remove permissions from a user
+- Approve applications and/or bots
+- and more.
+
+This team has no decision making power on its own, but is instead there to serve the needs of the Flux maintainers and contributors.
+
+**Defined by:** entry in [ORG-ADMINS file](https://github.com/fluxcd/community/blob/main/ORG-ADMINS), and in the `@fluxcd/org-admins` GitHub team.
+
+**Responsibilities and Privileges:**
+
+`admin` level access to the `fluxcd` organization in GitHub.
+
 <!-- md links -->
 [Community Member]: #community-member
 [Project Member]: #project-member
 [Maintainer]: #maintainer
 [core maintainers]: #core-maintainers
+[Org Admins]: #org-admins


### PR DESCRIPTION
Following up on various discussion threads lately @scottrigby and myself (with the help of other Flux maintainers and TAG Contributor Strategy folks) looked into 

1. replacing the Flux Oversight Committee with governance that is transparently agreed on and closer to how decisions are actually made (The idea behind this was to have a very simple governance change.)
2. bringing our Governance closer to what the Governance WG has put together as recommendation for projects of our structure (e.g. having a maintainer's council): https://github.com/cncf/project-template/blob/main/GOVERNANCE-maintainer.md

While the PR might look a bit long, a lot of pieces of text were copied over from the template as mentioned above and other pieces, e.g. the process definitions into a separate doc called `PROCESS.md`, so we can direct users to one place for "how to interact with the Flux project".

Here is a list of key changes (feel free to check individual commits on this PR to get a better idea of what changed):

- Replace the Oversight Committee (which was not really used in our former governance structure) with the "flux 2 maintainers" as an escalation point. It is currently the group in our project where things are most often decided and the one where members have to demonstrate the deepest involvement beforehand. (The Oversight Committee was decided back in the day, it was never voted in.)
- Code of Conduct: copied from template. It is clearer now and has a section for what to do if the violator is a maintainer.
- Add a section about team meetings (copied as well), so we can define it as an expectation for project members and maintainers.
-  Add a section explaining that almost all decisions are found through (lazy) consensus and that if we can't make decisions, we strive to work with our friends in adjacent communities and CNCF counterpart groups.
- Move process related bits into `PROCESS.md`.
- Expectations for members and maintainers: copy over some lingo from template to broaden our idea of contributions (docs, etc as well) and to give a more concrete idea what "sustained and significant contributions" mean. Set context for 'expected contributions' example - we want to allow for some flexibility. Underline 'ask for help/feedback'.
- Allow for core maintainers to be removed when inactive as well.
- Require 2fa on GitHub from maintainers.
- Further specify unanimity option to prevent a potential future impasse. Decisions can have a deadline date defined by which a quorum of 2/3 is sufficient, but consensus necessary (no veto votes). Define what we mean by Simple Majority and Supermajority
- Define Org Admins team who have full access to the `fluxcd` organisation in GitHub - current members: Flux Oversight Committee + CNCF / LF members.

Follow-up items

- [ ] Rename `@fluxcd/flux2-maintainers` team to `@fluxcd/core-maintainers`
- [ ] Add `@fluxcd/org-admins` team
- [ ] Replace https://github.com/fluxcd/flux2/blob/main/MAINTAINERS content with link to https://github.com/fluxcd/community/blob/main/CORE-MAINTAINERS
- [ ] Update https://github.com/fluxcd/community/tree/main/project to work with new structure
- [ ] Review Org Admin team - see if we have new applicants
- [ ] Set up annual reminder to review Org Admin team
- [ ] Document that the process for reporting CoC violations is to reach out to the private Flux maintainers list


Please leave feedback, we'd love to hear from all of you.