### PR TITLE
Document how Security Team members are added

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -101,6 +101,7 @@ For these kinds of decisions, a deadline can be given, and unanimity with a quor
 
 - Repository [Maintainers][Maintainer]: Electing new Maintainers of the same repository.
 - [core maintainers]: Removing a Maintainer of any repository for any reason other than inactivity.
+- Adding a [Security Team member]
 
 ## Licenses and Copyright
 
@@ -118,3 +119,4 @@ Links to relevant CNCF documentation:
 [core maintainers]: community-roles.md#core-maintainers
 [org admins]: community-roles.md#org-admins
 [community-roles.md]: community-roles.md
+[Security Team member]: community-roles.md#security-team-member

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -77,6 +77,24 @@ Once the above process has taken its course, make sure you
 
 **Applying as core maintainer:** The same process applies for applying as a core maintainer. The PR should be against the [CORE-MAINTAINERS file](https://github.com/fluxcd/community/blob/main/CORE-MAINTAINERS) though and an accordingly higher level of experience and a more holistic understanding of the project is expected.
 
+### Applying as a Security Team member
+
+**Process:**
+
+- You need to be a [Maintainer] to be able to apply
+- Set up your [Keybase](https://keybase.io) account
+- Make a PR against the `SECURITY.md` file in <https://github.com/fluxcd/.github> adding your contact information
+- @mention `@fluxcd/core-maintainers`
+- Have maintainers submit their vote by `+1`
+- Once all maintainers in repo have `+1` the PR will be reviewed by a member of the [core maintainers]
+
+Adding new Security Team members is an [Unanimity decision][unanimity-decisions].
+
+Once the above process has taken its course, make sure you
+
+- Ping [CNCF Service Desk](https://cncfservicedesk.atlassian.net/) to get you added as [Security Team member]
+- Ping fellow Security Team members to give you access to all the internal information
+
 ## Proposal Process
 
 - Code changes should go through the pull request process, where the idea and implementation details can be publicly discussed with [Maintainers][Maintainer], other contributors, and end users.
@@ -172,3 +190,4 @@ The list of members is reviewed every year and should consist of:
 [core maintainers]: community-roles.md#core-maintainers
 [supermajority-decisions]: GOVERNANCE.md#supermajority-decisions
 [unanimity-decisions]: GOVERNANCE.md#unanimity-decisions
+[Security Team member]: community-roles.md#security-team-member

--- a/community-roles.md
+++ b/community-roles.md
@@ -10,6 +10,7 @@ Roles are progressive, so each include responsibilities, requirements and defini
   - [Project Member](#project-member)
   - [Maintainer](#maintainer)
   - [Core maintainers](#core-maintainers)
+  - [Security team member](#security-team-member)
   - [Org Admins](#org-admins)
 
 ## Roles
@@ -112,6 +113,24 @@ The following apply to all assets across the Flux org:
 - Managing financial decisions
 - Defining the scope of each Git repository
 - Resolving escalated decisions when Maintainers responsible are blocked
+
+### Security Team member
+
+Security Team members are listed in the [SECURITY.md file](https://github.com/fluxcd/.github/blob/main/SECURITY.md#security-team).
+
+Members of this team handle security issues for the Flux projects. It is essential for us to deal with security-related concerns responsibly and follow the high standards of the security community as a whole.
+
+**Defined by:** entry in [SECURITY.md file](https://github.com/fluxcd/.github/blob/main/SECURITY.md#security-team).
+
+**Responsibilities and Privileges:**
+
+The following apply to all assets across the Flux org:
+
+- All reports are thoroughly investigated by the Security Team.
+- Any vulnerability information shared with the Security Team will not be shared with others unless it is necessary to fix the issue. Information is shared only on a need to know basis.
+- As the security issue moves through the identification and resolution process, the reporter will be notified.
+- Additional questions about the vulnerability may also be asked of the reporter.
+- Security Team members have a duty of care to the uphold of the Security embargo policy.
 
 ### Org Admins
 


### PR DESCRIPTION
Fixes: #214, #33

This is the one team we haven't defined in our governance yet. In addition to that @scottrigby and I wanted to clarify that keybase right now is only used for Security Team matters.

~~The one piece in this PR I was not sure about was the "core maintainer" requirement for being a Security Team member. It made sense to me though as that's what's required to be able to publish releases for everything.~~ After talking to @hiddeco we felt that for handling e.g. Comms (which is essential to the team) being a Flux maintainer is good enough.

Let me know what you think.

Signed-off-by: Daniel Holbach <daniel@weave.works>