### PR TITLE
Add oss-fuzz responsibility

### DIFF
--- a/PROCESS.md
+++ b/PROCESS.md
@@ -92,8 +92,9 @@ Adding new Security Team members is an [Unanimity decision][unanimity-decisions]
 
 Once the above process has taken its course, make sure you
 
-- Ping [CNCF Service Desk](https://cncfservicedesk.atlassian.net/) to get you added as [Security Team member]
-- Ping fellow Security Team members to give you access to all the internal information
+- Ping [CNCF Service Desk](https://cncfservicedesk.atlassian.net/) to get you added as [Security Team member].
+- Make a PR against [oss-fuzz](https://github.com/google/oss-fuzz/blob/e51830c2d428e672b405f9692adc82c57c1a6c5a/projects/fluxcd/project.yaml#L4-L9) to add your email.
+- Ping fellow Security Team members to give you access to all the internal information.
 
 ## Proposal Process
 

--- a/community-roles.md
+++ b/community-roles.md
@@ -129,6 +129,7 @@ The following apply to all assets across the Flux org:
 - All reports are thoroughly investigated by the Security Team.
 - Any vulnerability information shared with the Security Team will not be shared with others unless it is necessary to fix the issue. Information is shared only on a need to know basis.
 - As the security issue moves through the identification and resolution process, the reporter will be notified.
+- Security Team members must use their access to the [oss-fuzz issues catalog](https://bugs.chromium.org/p/oss-fuzz/) to investigate issues raised from fuzz tests.
 - Additional questions about the vulnerability may also be asked of the reporter.
 - Security Team members have a duty of care to the uphold of the Security embargo policy.
 


### PR DESCRIPTION
@hiddeco @scottrigby please share your views on this.

Do we need to capture somewhere all the access people should attain when they become part of the Security Team?
This would help keeping the accesses in line once folks move on from the team as well.

Here's an example of access that needs to be managed as part of the Security Team membership:
https://github.com/google/oss-fuzz/blob/master/projects/fluxcd/project.yaml#L4-L9