### PR TITLE
Remove @alisondy from Maintainers (inactive)

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -7,3 +7,9 @@ In alphabetical order:
 Daniel Holbach, Weaveworks <daniel@weave.works> (github: @dholbach, slack: dholbach)
 Stefan Prodan, Weaveworks <stefan@weave.works> (github: @stefanprodan, slack: stefanprodan)
 Scott Rigby, Weaveworks <scott@weave.works> (github: @scottrigby, slack: scottrigby)
+
+Retired maintainers:
+
+- Alison Dowdney
+
+Thank you for your involvement, and let us not say "farewell" ...

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -4,7 +4,6 @@ https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages
 
 In alphabetical order:
 
-Alison Dowdney, Independent <alison@alisondowdney.com> (github: @alisondy, slack: alisondy)
 Daniel Holbach, Weaveworks <daniel@weave.works> (github: @dholbach, slack: dholbach)
 Stefan Prodan, Weaveworks <stefan@weave.works> (github: @stefanprodan, slack: stefanprodan)
 Scott Rigby, Weaveworks <scott@weave.works> (github: @scottrigby, slack: scottrigby)


### PR DESCRIPTION
Per discussion in slack, @alisondy is inactive as a Flux maintainer.