### PR TITLE
Add Kingdon to Maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -4,6 +4,7 @@ https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages
 
 In alphabetical order:
 
+Kingdon Barrett, Weaveworks <kingdon@weave.works> (github: @kingdonb, slack: Kingdon B)
 Daniel Holbach, Weaveworks <daniel@weave.works> (github: @dholbach, slack: dholbach)
 Stefan Prodan, Weaveworks <stefan@weave.works> (github: @stefanprodan, slack: stefanprodan)
 Scott Rigby, Weaveworks <scott@weave.works> (github: @scottrigby, slack: scottrigby)


### PR DESCRIPTION
@scottrigby @stefanprodan @dholbach @alisondy 

It says in the process document that I should ping all current maintainers and the vote passes if we get a 👍 from everyone

I think I understand that maintainers can be removed due to inactivity without a vote, but as long as there are inactive maintainers (still listed) who cannot be reached, then consensus cannot be obtained, and we would be blocked from updating the maintainers list. At least that's according to my understanding of how it works, please correct if I'm wrong!

https://github.com/fluxcd/community/blob/main/PROCESS.md#applying-for-flux-maintainership

* #232 is already approved, so I do not know if it's necessary to also wait for Alison's vote

(but I cannot merge it myself as I am not a maintainer yet)