### PR TITLE
Document project members

### DIFF
--- a/PROCESS.md
+++ b/PROCESS.md
@@ -17,7 +17,7 @@ As foundational documents such as [GOVERNANCE.md](GOVERNANCE.md) and [community-
   - Contributing to project or community discussions (for example meetings, Slack, email discussion forums, Stack Overflow)
 - Subscribed to the [flux-dev mailing list](https://lists.cncf.io/g/cncf-flux-dev/join)
 - Actively contributing to 1 or more `fluxcd` GitHub org repos
-- Sponsored by 2 project members  
+- Sponsored by 2 project members
   **Note the following requirements for sponsors:**
   - At least 1 of the sponsors must be a maintainer
   - Sponsors must have close interactions with the prospective member - for example code/design/proposal review, coordinating on issues, etc.
@@ -54,6 +54,7 @@ As foundational documents such as [GOVERNANCE.md](GOVERNANCE.md) and [community-
 
 - Have your sponsoring members/maintainers reply confirmation of sponsorship: `+1`
 - Once your sponsors have responded, your request will be reviewed by a member of the [core maintainers].
+- Add yourself to the list of [Flux Project Members](PROJECT-MEMBERS.md) afterwards.
 
 Any missing information will be requested.
 

--- a/PROJECT-MEMBERS.md
+++ b/PROJECT-MEMBERS.md
@@ -1,0 +1,10 @@
+# Flux Project Members
+
+Here is a list of our [Flux Project Members](community-roles.md#project-member)
+who are not maintainers (yet).
+
+| Name            | GitHub Handle | Slack Handle  | Affiliation | Application |
+| --------------- | ------------- | ------------- | ----------- | ----------- |
+| Stacey Potter   | @staceypotter | Stacey Potter | Weaveworks  | Issue #210  |
+| Ihor Sychevskyi | @arhell       | Arhell        | SmartCats   | Issue #202  |
+| Leigh Capili    | @stealthybox  | stealthybox   | VMware      | Issue #234  |

--- a/community-roles.md
+++ b/community-roles.md
@@ -40,6 +40,7 @@ This can be through code, documentation, taking part in bug scrubs, etc.
 
 - [Triage role](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization#repository-access-for-each-permission-level) on all `fluxcd` GitHub org repos
 - [Membership](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-user-account/managing-your-membership-in-organizations/about-organization-membership) in the [fluxcd org](https://github.com/fluxcd)
+- Current Flux Project Members [are listed here](PROJECT-MEMBERS.md)
 
 **Responsibilities and privileges:**
 


### PR DESCRIPTION
As a follow-up to #240, document current Flux Project Members to make it easier for new applicants to find out who could be a sponsor.

~~Only merge after #240 has been landed.~~

Signed-off-by: Daniel Holbach <daniel@weave.works>
