### PR TITLE
fix sorting and avoid listing current maintainers

### DIFF
--- a/project/bin/get_maintainer_data
+++ b/project/bin/get_maintainer_data
@@ -106,7 +106,7 @@ def write_rolodex(info):
 
 def write_emeriti(info):
     data = {}
-    for repo in info:
+    for repo in sorted(info):
         if info[repo]['emeriti']:
             emeriti = list(info[repo]['emeriti'])
             emeriti.sort()
@@ -143,10 +143,13 @@ def main():
         info[repo]['emeriti'] = emeriti
         info[repo]['maintainers'] = {}
         for m in maintainers:
+            current_maintainer = False
             for r in info:
-                if m in info[r]['maintainers']:
-                    continue
-            info[repo]['emeriti'].add(m[0])
+                if m[0] in [m[0] for m in info[r]['maintainers']]:
+                    current_maintainer = True
+                    break
+            if not current_maintainer:
+                info[repo]['emeriti'].add(m[0])
 
     write_rolodex(info)
     write_emeriti(info)


### PR DESCRIPTION
#259 was not quite what we wanted. With this PR, the output will be

```diff
diff --git a/project/flux-project-emeriti.yaml b/project/flux-project-emeriti.yaml
index d603e81e..e7cb43b9 100644
--- a/project/flux-project-emeriti.yaml
+++ b/project/flux-project-emeriti.yaml
@@ -4,6 +4,7 @@ community:
 flux:
 - Alfonso Acosta
 - Justin Barrick
+- Michael Bridgen
 - Nick Cabatoff
 go-git-providers:
 - Dinos Kousidis
@@ -13,6 +14,7 @@ helm-controller:
 - Sean Eagan
 helm-operator:
 - Alfonso Acosta
+- Michael Bridgen
 website:
 - Alison Dowdney
 webui:
diff --git a/project/flux-project-maintainers.yaml b/project/flux-project-maintainers.yaml
index 12dcacd3..80b8e90d 100644
--- a/project/flux-project-maintainers.yaml
+++ b/project/flux-project-maintainers.yaml
@@ -8,11 +8,6 @@ flagger:
 - aryan9600
 - stefanprodan
 - mathetake
-flux:
-- hiddeco
-- kingdonb
-- squaremo
-- stefanprodan
 flux2:
 - relu
 - hiddeco
@@ -26,10 +21,6 @@ go-git-providers:
 - souleb
 - stefanprodan
 - yiannistri
-helm-operator:
-- hiddeco
-- squaremo
-- stefanprodan
 image-automation-controller:
 # Plus flux2 maintainers
 - pjbgf
diff --git a/project/rolodex.yaml b/project/rolodex.yaml
index 5debe45f..ea1e1639 100644
--- a/project/rolodex.yaml
+++ b/project/rolodex.yaml
@@ -7,6 +7,7 @@ emeriti:
 - Jordan Pellizzari
 - Justin Barrick
 - Michael Beaumont
+- Michael Bridgen
 - Nick Cabatoff
 - Sara El-Zayat
 - Sean Eagan
@@ -81,11 +82,6 @@ maintainers:
     email: soule@weave.works
     affiliation: Weaveworks
     slack: souleb
-- squaremo:
-    name: Michael Bridgen
-    email: michael@weave.works
-    affiliation: Weaveworks
-    slack: Michael Bridgen
 - stefanprodan:
     name: Stefan Prodan
     email: stefan@weave.works

```

Signed-off-by: Daniel Holbach <daniel@weave.works>