### PR TITLE
Update access list in COMMUNITY.md

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -107,6 +107,7 @@ For people listed below we made exceptions:
 | -- | -- | -- | -- |
 | Stacey Potter   | `@Stacey Potter` | `@staceypotter` | Dynatrace  |
 | Tamao Nakahara  | `@tamao`         | `@mewzherder`   | Weaveworks |
+| Kingdon Barrett | `@KingdonB`      | `@kingdonb`     | Weaveworks |
 
 #### LinkedIn Group
 
@@ -130,7 +131,8 @@ For people listed below we made exceptions:
 
 | Name | Slack handle | Github handle | Affiliation |
 | -- | -- | -- | -- |
-| Stacey Potter   | `@Stacey Potter` | `@staceypotter` | Dynatrace |
+| Stacey Potter   | `@Stacey Potter` | `@staceypotter` | Dynatrace  |
+| Kingdon Barrett | `@Kingdon B`     | `@kingdonb`     | Weaveworks |
 
 [flux-drive]: https://drive.google.com/drive/folders/1884_42hqE02EHq8GrhkeIMC4WSFPsdTW?usp=share_link
 [comms-plan]: https://docs.google.com/spreadsheets/d/1hPV3qJ95I_RKPyeo3zUJOPrHc0LNeSlP3f9fjXTen-c/edit#gid=0


### PR DESCRIPTION
I realize that the document reads:

> Access to things
> In case you need access to a particular Flux resource to fulfil your role as team member, please [file an issue on this repository](https://github.com/fluxcd/community/issues/new) and tag some of the folks in the previous section.

> Below we list resources that are not tied to GitHub permissions. You can assume that the core Flux maintainers have access, maintainers of the community repository and sometimes CNCF staff as backup.

> For people listed below we made exceptions:

and so, that I am a maintainer on the COMMUNITY team means I should probably not put my name in this list, however. There are some things in this list that I do not have access to (namely Twitter, LinkedIn) even now, as a maintainer ...

I got halfway into crafting this PR before I understood that from reading the `COMMUNITY.md` document a couple of times. Still I wonder if we shouldn't revisit this list and make sure that all access listings are correct and current! While I'm here...

Are there any core maintainers who need access to any more of these socials than they currently do have? Let's have a check-in here on the issue, for anyone who is interested—is there at least someone active on the maintainers team with current manager-level access to each of these?

- [x] FluxCD LinkedIn Group
- [x] FluxCD Twitter Handle
- [X] FluxCD YouTube Channel

(This may also serve as a call for volunteers!)