### PR TITLE
add gitopsdays.com to lycheeignore

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,3 @@
 https://twitter.com/fluxcd
 https://docs.github.com
+https://www.gitopsdays.com


### PR DESCRIPTION
The gitopsdays.com website is 404

```
✗ [ERR] https://www.gitopsdays.com/ | Failed: Network error: error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:2092: (hostname mismatch)
```

On the bright side, link checker cron is apparently working again 🎉

https://github.com/fluxcd/community/actions/runs/8029740079/job/21936367099