### PR TITLE
Only open issue when lychee-cron errors

### DIFF
--- a/.github/workflows/lychee-cron.yaml
+++ b/.github/workflows/lychee-cron.yaml
@@ -22,6 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create Issue From File
+        if: env.lychee_exit_code != 0
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: Link Checker Report


### PR DESCRIPTION
Fix #358

(Maybe we don't need to check every day. We can alter it further to reduce the frequency, or we can try changing this workflow again if it is too spammy, but...) I can see here:

https://github.com/fluxcd/community/actions/runs/8039800248/job/21957184276#step:4:9

the `env.lychee_exit_code=0` is correctly set, we just don't implement the if statement in our workflow, so the issue is opened even when there is no error.

I am not sure if this workflow ever worked before. It seems surprising that it has been running every day and erroring out and nobody noticed before! But here we are.