### PR TITLE
Fix pre/code format in Update KUBECON.md workflow

### DIFF
--- a/KUBECON.md
+++ b/KUBECON.md
@@ -3,14 +3,14 @@
 # KubeCon activities!
 
 
-    {{< figure src="img/flux-horizontal-color.png" alt="Flux Logo" class="flux-logo-inner-header-left" >}}
+{{< figure src="/img/flux-horizontal-color.png" alt="Flux Logo" class="flux-logo-inner-header-left" >}}
 
 # KubeCon Paris 2024
 
 March 19-22, 2024
 
 
-    {{< figure src="img/blob-waving.gif" alt="Blob Waving" class="inner-header-right-align" >}}
+{{< figure src="/img/blob-waving.gif" alt="Blob Waving" class="inner-header-right-align" >}}
 
 # Flux news!
 
@@ -19,7 +19,7 @@ March 19-22, 2024
 [Second Security audit: No CVEs!](https://fluxcd.io/blog/2023/11/flux-security-audit/)
 
 
-    {{< figure src="img/flux-cuttlefish-stickers.jpeg" alt="Custom printed stickers with cuttlefish mascot and Flux logos" class="stickers-float-left" >}}
+{{< figure src="/img/flux-cuttlefish-stickers.jpeg" alt="Custom printed stickers with cuttlefish mascot and Flux logos" class="stickers-float-left" >}}
 
 # Flux Booth fun!
 

--- a/script/update-kubecon.sh
+++ b/script/update-kubecon.sh
@@ -27,11 +27,11 @@ wget ${SOURCE_SITE} -O ${TEMP_FILE} \
   | sed 's_/view/flux-kubecon-paris-2024/home_/kubecon_' \
   | sed -E 's_\[!\[\]\([^)]+\)_[_g' \
   | sed -E 's_!\[flux-logo-inner-header-left[^)]+\)_\
-    {{< figure src="img/flux-horizontal-color.png" alt="Flux Logo" class="flux-logo-inner-header-left" >}}_g' \
+{{< figure src="/img/flux-horizontal-color.png" alt="Flux Logo" class="flux-logo-inner-header-left" >}}_g' \
   | sed -E 's_!\[inner-header-right-align[^)]+\)_\
-    {{< figure src="img/blob-waving.gif" alt="Blob Waving" class="inner-header-right-align" >}}_g' \
+{{< figure src="/img/blob-waving.gif" alt="Blob Waving" class="inner-header-right-align" >}}_g' \
   | sed -E 's_!\[stickers-float-left[^)]+\)_\
-    {{< figure src="img/flux-cuttlefish-stickers.jpeg" alt="Custom printed stickers with cuttlefish mascot and Flux logos" class="stickers-float-left" >}}_g' \
+{{< figure src="/img/flux-cuttlefish-stickers.jpeg" alt="Custom printed stickers with cuttlefish mascot and Flux logos" class="stickers-float-left" >}}_g' \
     > ${OUT_FILE}
 
 if [[ -z "$DEBUG" ]]; then


### PR DESCRIPTION
Four spaces in front of the line makes it a `<code>` block, whoops

Also, the images are at `/img/...` not at relative `img/...`