### PR TITLE
Fix podinfo link

### DIFF
--- a/.github/workflows/update-kubecon.yaml
+++ b/.github/workflows/update-kubecon.yaml
@@ -34,3 +34,4 @@ jobs:
   
               [1]: https://github.com/peter-evans/create-pull-request
             branch: update-kubecon
+            signoff: true

--- a/KUBECON.md
+++ b/KUBECON.md
@@ -28,7 +28,7 @@
 </div>
 
 
-<div class="float-booth-fun"><h1>Flux Booth fun!</h1><p>Want a bespoke unique all-your-own cuttlefish sticker? Complete the challenge and pick up a human-intelligence or artificial-intelligence Flux sticker! Deploy [the podinfo sample app](https://github.com/stefanprodan/podinfo) and change the text to something like "Cuttlefish playing tennis" and then come by the Flux booth at KubeCon. 😸👩🏻‍🎨🎨</p><p>Visit the Flux booth in the KubeCon Project Pavilion to meet the Flux maintainers and contributors for demos and fun!</p></div></div>
+<div class="float-booth-fun"><h1>Flux Booth fun!</h1><p>Want a bespoke unique all-your-own cuttlefish sticker? Complete the challenge and pick up a human-intelligence or artificial-intelligence Flux sticker! Deploy <a href="https://github.com/stefanprodan/podinfo">the podinfo sample app</a> and change the text to something like "Cuttlefish playing tennis" and then come by the Flux booth at KubeCon. 😸👩🏻‍🎨🎨</p><p>Visit the Flux booth in the KubeCon Project Pavilion to meet the Flux maintainers and contributors for demos and fun!</p></div></div>
 
 # Flux talks @ KubeCon Paris!
 

--- a/script/update-kubecon.sh
+++ b/script/update-kubecon.sh
@@ -31,6 +31,7 @@ fi
 # sed 4-6: detect the images from their alt tags, then replace with figure refs
 # sed 7: the header which is meant to float between images must also have float
 # sed 8: flux booth fun (a caption with a heading h1 followed by two paragraphs!)
+# sed 9: the podinfo sample app link is in an HTML block so :( turn it manually into a link
 wget ${SOURCE_SITE} -O ${TEMP_FILE} \
   && ${HTML2MD_BIN} -i ${TEMP_FILE} |$sed '1,6d'|$head -n -13 \
   | $sed 's_# \[Copy heading link\](\\#h\.[a-z0-9]*)[[:space:]]*_# _' \
@@ -53,6 +54,7 @@ wget ${SOURCE_SITE} -O ${TEMP_FILE} \
   | $sed -z 's_# KubeCon Paris 2024\n\nMarch 19-22, 2024_<div class="float-header-kubecon"><h1>KubeCon Paris 2024</h1><p>March 19-22, 2024</p></div>_' \
   | $sed -Ez 's_# Flux Booth fun!\n\n([^\n]+)\n\n([^\n]+)\n\n#_\
 <div class="float-booth-fun"><h1>Flux Booth fun!</h1><p>\1</p><p>\2</p></div></div>\n\n#_' \
+  | $sed -E 's_\[the podinfo sample app\]\(https://github.com/stefanprodan/podinfo\)_<a href="https://github.com/stefanprodan/podinfo">the podinfo sample app</a>_' \
     > ${OUT_FILE}
 
 if [[ -z "$DEBUG" ]]; then


### PR DESCRIPTION
This link happens to be in a column (which requires an HTML block)

If there is a better way to fix this I don't know it, but this was pretty quick and easy to write. There's only one link with this problem.

This script is getting more brittle as I go along, we can improve it, but right now it's sprint to the finish because we can't be working on this up to the last minute before Kubecon :D 

