### PR TITLE
GHA Workflow: Push to website trigger

### DIFF
--- a/.github/workflows/push-website.yaml
+++ b/.github/workflows/push-website.yaml
@@ -58,7 +58,7 @@ jobs:
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_BOT_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.BOT_GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
             -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$version\", \"unit\": false, \"integration\": true}}"

--- a/.github/workflows/push-website.yaml
+++ b/.github/workflows/push-website.yaml
@@ -1,0 +1,64 @@
+name: Push to Website
+  # When a change comes in the main branch on any of the files listed as
+  # external-sources in the fluxcd/website repository, trigger a rebuild
+  # without delay. The rebuild is scheduled for once every 6 hours. With
+  # this automation, the rebuild should proceed immediately after a PR is
+  # merged to the fluxcd/community repo, only if it changes one of these.
+  #
+  # Combination of example workflows:
+  # https://how.wtf/run-workflow-step-or-job-based-on-file-changes-github-actions.html
+  # https://medium.com/hostspaceng/triggering-workflows-in-another-repository-with-github-actions-4f581f8e0ceb
+  #
+  # This workflow monitors the "main" branch for changes to any of the files in
+  # community repo that are listed as "external-sources" in the fluxcd/website
+  # repo, then upon detecting changes fires the "Netlify" workflow in website
+  # to trigger rebuild of https://fluxcd.io (and redeploy of the said content)
+on:
+  # 
+  # workflow-dispatch:  # NB: this is disabled on-purpose. The push filter conflicts with workflow-dispatch
+  #                     # because there is no push event to filter changes based upon. If you want to trigger
+  #                     # the netlify job in fluxcd/website, go trigger it directly. (You may need access!)
+  #                     # There is no manual workflow-dispatch here, this workflow is for better automation.
+  #                     # The fluxcd/website#netlify job also will rebuild itself on a schedule (*/6 hours)
+  #
+  push:
+    branches:
+    - main 
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      external: ${{ steps.changes.outputs.external }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v3
+      id: changes
+      with:
+        filters: |
+          external:
+            - 'README.md'
+            - 'GOVERNANCE.md'
+            - 'KUBECON.md'
+
+  trigger:
+    needs: changes
+    if: ${{ needs.changes.outputs.external == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger fluxcd/website#netlify workflow
+        run: |
+          # Set the required variables
+          repo_owner="fluxcd"
+          repo_name="website"
+          event_type="trigger-workflow"
+          service=netlify
+          version=main
+
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_BOT_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
+            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$version\", \"unit\": false, \"integration\": true}}"


### PR DESCRIPTION
This is a combination of two workflow examples I found:

Combination of example workflows:
  - https://how.wtf/run-workflow-step-or-job-based-on-file-changes-github-actions.html
  - https://medium.com/hostspaceng/triggering-workflows-in-another-repository-with-github-actions-4f581f8e0ceb

The workflow I created here is a continuation of the discussion in #362 

https://github.com/fluxcd/community/pull/362#issuecomment-1970710532

This way KUBECON.md gets pulled in immediately on merge of the change in fluxcd/community, instead of up to 6 hours later when the netlify job runs on the regular interval. This should get us closer to the user experience that we expected.

This workflow only triggers its jobs when there are changes to one of the three files listed, on the `main` branch.

It requires a small change to the fluxcd/website repo so that the Netlify job can be triggered remotely similar to workflow_dispatch, (or perhaps we can just use the workflow dispatch, I'm not certain that I understand the difference):

* https://github.com/fluxcd/website/pull/1840

This likely will also require some admin to configure an additional permission for the bot token in this repo, to be able to trigger the Netlify workflow on fluxcd/website to be triggered remotely across repos.

@stefanprodan Please let me know if you think I should use this secret or a different secret name than `BOT_GITHUB_TOKEN`, or if you think you will need to create another one. I used `BOT_GITHUB_TOKEN` for now. 🙏 

> Note: You should generate your own Personal Access Token (PAT) with the required permissions to enable you to trigger workflows in other repositories. (From: https://medium.com/hostspaceng/triggering-workflows-in-another-repository-with-github-actions-4f581f8e0ceb#bc81)

This PR has been tested for trigger/filter logic here:
https://github.com/kingdonb/community/actions/runs/8131160884/job/22220175011
and again here:
https://github.com/fluxcd/community/pull/365#issuecomment-1975211738

I'd say it's pretty well tested now.

I'll meet with @mewzherder either before or after we merge it, some time this week, to be sure we both know how this job works. It would be great to have a backup, since I'm going to be incommunicado starting after this week, for almost two weeks directly before and until Wednesday of Kubecon!

To be clearer, I am looking for one of the other maintainers here (perhaps besides @stefanprodan) to also review this workflow and understand how it works.