### PR TITLE
For Kubecon: should we make update faster?

### DIFF
--- a/.github/workflows/update-kubecon.yaml
+++ b/.github/workflows/update-kubecon.yaml
@@ -1,7 +1,7 @@
 name: Update Kubecon.md
 on:
   schedule:
-    - cron:  '0 */6 * * *'
+    - cron:  '*/5 * * * *'
   workflow_dispatch:
 jobs:
   update-kubecon:


### PR DESCRIPTION
We can merge this any time. It should be reverted after Kubecon Paris

This PR makes the `update-kubecon.md` cron job run every 5 minutes, instead of every 6 hours which it is currently set at. It should make working with the Google Sites integration a lot more convenient

If you want, we can edit the Pull Request so it sends you email - then you can click through the email and merge the PR to deploy to the website. The delay should be less than 5 minutes. Netlify job takes about 1 minute 30s to build the docs site.

I wanted to test this workflow very thoroughly before I set the job to run that frequently. I still think this may be too fast. But someone else from the community repo will have to weigh in anyway, I cannot merge this by myself.

cc: @mewzherder 