### PR TITLE
Retire phillebaba as core maintainer

### DIFF
--- a/CORE-MAINTAINERS
+++ b/CORE-MAINTAINERS
@@ -16,8 +16,13 @@ Aurel Canciu, NexHealth <aurel.canciu@nexhealth.com> (github: @relu, slack: relu
 Hidde Beydals, Weaveworks <hidde@weave.works> (github: @hiddeco, slack: hidde)
 Max Jonas Werner, Associmates <max.werner@associmates.eu> (github: @makkes, slack: max)
 Paulo Gomes, SUSE <pjbgf@linux.com> (github: @pjbgf, slack: pjbgf)
-Philip Laine, Xenit <philip.laine@xenit.se> (github: @phillebaba, slack: phillebaba)
 Sanskar Jaiswal, Independent <jaiswalsanskar078@gmail.com> (github: @aryan9600, slack: aryan9600)
 Soule BA, Independent <bah.soule@gmail.com> (github: @souleb, slack: souleb)
 Stefan Prodan, ControlPlane <stefan.prodan@gmail.com> (github: @stefanprodan, slack: stefanprodan)
 Sunny, Independent <sunny@darkowlzz.space> (github: @darkowlzz, slack: darkowlzz)
+
+Retired maintainers:
+
+- Philip Laine
+
+Thank you for your involvement, and let us not say "farewell" ...


### PR DESCRIPTION
Philip messaged us in November 2023 that he wants to step down as core maintainer.

Thanks @phillebaba for all the great work you've done in Flux over the years 🤗 