### PR TITLE
Disable KubeCon cron schedule

### DIFF
--- a/.github/workflows/update-kubecon.yaml
+++ b/.github/workflows/update-kubecon.yaml
@@ -1,7 +1,7 @@
 name: Update Kubecon.md
 on:
   schedule:
-    - cron:  '0 */6 * * *'
+    # - cron:  '0 */6 * * *'
   workflow_dispatch:
 jobs:
   update-kubecon:


### PR DESCRIPTION
KubeCon is over, and we removed the KubeCon menu entry, there should be no further updates to the KUBECON.md for now

Leaving the workflow intact because we can obviously reuse it later

Ref:

* https://github.com/fluxcd/website/pull/1804
* https://github.com/fluxcd/community/pull/349