### PR TITLE
Schedule is invalid

### DIFF
--- a/.github/workflows/update-kubecon.yaml
+++ b/.github/workflows/update-kubecon.yaml
@@ -1,6 +1,6 @@
 name: Update Kubecon.md
 on:
-  schedule:
+  # schedule: []
     # - cron:  '0 */6 * * *'
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
https://github.com/fluxcd/community/actions/runs/8467767683

```
Invalid workflow file
`schedule` accepts a list of one or more maps with the `cron` key set
```

(This should fix it)