### PR TITLE
Add shortcode for calendar table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 
 We want the [Flux project](https://github.com/fluxcd) to be the vendor-neutral home for GitOps in a Cloud Native world.
 
-Started 2016 to automate deployments at Weaveworks, the project has grown dramatically since then.
-Especially since the planning of Flux v2 and GitOps Toolkit SDK it was clearer that the scope became
-more ambitious and that the Flux project has become the home for the Flux family of projects,
-all solving specific GitOps needs.
+Started in 2016 to automate deployments at Weaveworks, the project has taken on a new life since then.
+The Flux community has become the home for a family of projects, all solving specific GitOps needs.
 
 We also want our community to be diverse, helpful, collaborative and a fun place to be, so we would love to have you join us!
 
@@ -14,19 +12,37 @@ We also want our community to be diverse, helpful, collaborative and a fun place
 ### Meetings
 
 We run regular meetings and discuss things there.
-We are very happy if new users, contributors and developers join and we can put names to faces.
 
-Test import calendar table:
+The upcoming meetings, talks and community events in the next month are maintained here:
 
 {{< home/calendar >}}
 
-All meetings can be found on our calendar: <https://lists.cncf.io/g/cncf-flux-dev/calendar>
+Our calendar data is hosted on the CNCF-Flux-Dev List, which has the option to subscribe: <https://lists.cncf.io/g/cncf-flux-dev/calendar>
+
+We are very happy if new users, contributors and developers join and we can put names to faces!
+
+Review how to [subscribe to the Flux Calendar](#subscribing-to-the-flux-calendar) to add the Flux meetups on your own calendar.
+
+We are looking forward to seeing you there.
+
+#### Recordings
+
+Check out the <https://www.youtube.com/@fluxcd> channel for recordings of Flux Dev Meetings and other Flux-related playlists.
+
+#### Schedules
+
+The recurring meetings and their schedules (in English) are listed below with their source time zones, and a link to any meeting "Minutes" docs.
+
+Some regularly scheduled meetings are scheduled in their hosts' local time zones.
 
 | Which | Times | Agenda & Minutes | Recordings |
 | ----- | ----- | ---------------- | ---------- |
-| Flux Dev Meetings | "early" meeting: Uneven weeks: Wed, 12:00 UTC, "late" meeting: Even weeks: Thu, 15:00 UTC | [Document](https://docs.google.com/document/d/167SKpaDUrpiBqNR2lXnQjXyb5Gxq6uB-Fujz7eBQxyw/edit) | [YouTube](https://www.youtube.com/playlist?list=PLwjBY07V76p5mWNgdINjIiuUiItIeLhIN) |
+| Flux Dev Meetings | "early" meeting: Uneven weeks: Wed, 12:00 UTC <br/>"late" meeting: Even weeks: Thu, 15:00 UTC | [Document](https://docs.google.com/document/d/167SKpaDUrpiBqNR2lXnQjXyb5Gxq6uB-Fujz7eBQxyw/edit) | [YouTube](https://www.youtube.com/playlist?list=PLwjBY07V76p5mWNgdINjIiuUiItIeLhIN) |
+| Flux Bug Scrub | "early" meeting: Even weeks: Wed, 8:00 Eastern US time <br/>"late" meeting: Odd weeks: Thu, 13:00 Eastern US time <br/>"AEST Edition" Even weeks: Wed, 8:00 Brisbane time | [Bug Scrub Template (#0090)](https://docs.google.com/spreadsheets/d/1Hv9BIr0vFAOHscqYzmlKKG1Il18Nw8X_iiDyi0HRgCs/edit#gid=2133538565) | [YouTube](https://www.youtube.com/watch?v=c4unRRJp-o0&list=PLwjBY07V76p6J6z30cBRqS_N0Ka6NhEsY) |
 
-We are looking forward to seeing you there.
+Do note that Daylight Savings Time changes can vary across regions, which can cause some confusion.
+
+The calendar at <https://fluxcd.io/community#meetings> has been localized to show the events in your local time zone.
 
 ### Finding your interest
 
@@ -98,7 +114,7 @@ The codebase itself is a multi-component design, spread across multiple Git repo
 Flux also includes non-code contributions, such as documentation and community information.
 Maintainers of each repo are listed in a MAINTAINERS file in the root of that repo.
 
-See [project/flux-project-maintainers.yaml](./project/flux-project-maintainers.yaml) for an aggregated list of all maintainers from each of the project's individual Git repos.
+See [project/flux-project-maintainers.yaml](project/flux-project-maintainers.yaml) for an aggregated list of all maintainers from each of the project's individual Git repos.
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ Do note that Daylight Savings Time changes can vary across regions, which can ca
 
 The calendar at <https://fluxcd.io/community#meetings> has been localized to show the events in your local time zone.
 
+#### Subscribing to the Flux calendar
+
+To add the meetings to your e.g. Google calendar
+
+1. visit the [Flux calendar](https://lists.cncf.io/g/cncf-flux-dev/calendar)
+   > For this you might need to create an account for `lists.cncf.io`
+1. click on "Subscribe to Calendar" at the very bottom of the page
+1. copy the iCalendar URL
+1. open e.g. your Google calendar
+1. find the "add calendar" option
+1. choose "add by URL"
+1. paste iCalendar URL (ends with `.ics`)
+1. done
+
 ### Finding your interest
 
 To get started, it's important you find out which parts of Flux you are interested in first.
@@ -79,20 +93,6 @@ There currently are:
 
 All projects and teams are open to contributors and every part of the Flux project appreciates your help and consideration.
 Check out the links above to learn more about the team in question.
-
-#### Subscribing to the Flux calendar
-
-To add the meetings to your e.g. Google calendar
-
-1. visit the [Flux calendar](https://lists.cncf.io/g/cncf-flux-dev/calendar)
-   > For this you might need to create an account for `lists.cncf.io`
-1. click on "Subscribe to Calendar" at the very bottom of the page
-1. copy the iCalendar URL
-1. open e.g. your Google calendar
-1. find the "add calendar" option
-1. choose "add by URL"
-1. paste iCalendar URL (ends with `.ics`)
-1. done
 
 ## Communication
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 We want the [Flux project](https://github.com/fluxcd) to be the vendor-neutral home for GitOps in a Cloud Native world.
 
 Started in 2016 to automate deployments at Weaveworks, the project has taken on a new life since then.
-The Flux community has become the home for a family of projects, all solving specific GitOps needs.
+The Flux community has become the home for a family of projects, all solving a variety of specific GitOps needs.
 
 We also want our community to be diverse, helpful, collaborative and a fun place to be, so we would love to have you join us!
 
@@ -13,7 +13,7 @@ We also want our community to be diverse, helpful, collaborative and a fun place
 
 We run regular meetings and discuss things there.
 
-The upcoming meetings, talks and community events in the next month are maintained here:
+The upcoming meetings, talks, and community events for the next month are here:
 
 {{< home/calendar >}}
 
@@ -37,7 +37,7 @@ Some regularly scheduled meetings are scheduled in their hosts' local time zones
 
 | Which | Times | Agenda & Minutes | Recordings |
 | ----- | ----- | ---------------- | ---------- |
-| Flux Dev Meetings | "early" meeting: Uneven weeks: Wed, 12:00 UTC <br/>"late" meeting: Even weeks: Thu, 15:00 UTC | [Document](https://docs.google.com/document/d/167SKpaDUrpiBqNR2lXnQjXyb5Gxq6uB-Fujz7eBQxyw/edit) | [YouTube](https://www.youtube.com/playlist?list=PLwjBY07V76p5mWNgdINjIiuUiItIeLhIN) |
+| Flux Dev Meetings | "early" meeting: Odd weeks: Wed, 12:00 UTC <br/>"late" meeting: Even weeks: Thu, 15:00 UTC | [Document](https://docs.google.com/document/d/167SKpaDUrpiBqNR2lXnQjXyb5Gxq6uB-Fujz7eBQxyw/edit) | [YouTube](https://www.youtube.com/playlist?list=PLwjBY07V76p5mWNgdINjIiuUiItIeLhIN) |
 | Flux Bug Scrub | "early" meeting: Even weeks: Wed, 8:00 Eastern US time <br/>"late" meeting: Odd weeks: Thu, 13:00 Eastern US time <br/>"AEST Edition" Even weeks: Wed, 8:00 Brisbane time | [Bug Scrub Template (#0090)](https://docs.google.com/spreadsheets/d/1Hv9BIr0vFAOHscqYzmlKKG1Il18Nw8X_iiDyi0HRgCs/edit#gid=2133538565) | [YouTube](https://www.youtube.com/watch?v=c4unRRJp-o0&list=PLwjBY07V76p6J6z30cBRqS_N0Ka6NhEsY) |
 
 Do note that Daylight Savings Time changes can vary across regions, which can cause some confusion.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,23 @@ We also want our community to be diverse, helpful, collaborative and a fun place
 
 ## Getting involved
 
+### Meetings
+
+We run regular meetings and discuss things there.
+We are very happy if new users, contributors and developers join and we can put names to faces.
+
+Test import calendar table:
+
+{{< home/calendar >}}
+
+All meetings can be found on our calendar: <https://lists.cncf.io/g/cncf-flux-dev/calendar>
+
+| Which | Times | Agenda & Minutes | Recordings |
+| ----- | ----- | ---------------- | ---------- |
+| Flux Dev Meetings | "early" meeting: Uneven weeks: Wed, 12:00 UTC, "late" meeting: Even weeks: Thu, 15:00 UTC | [Document](https://docs.google.com/document/d/167SKpaDUrpiBqNR2lXnQjXyb5Gxq6uB-Fujz7eBQxyw/edit) | [YouTube](https://www.youtube.com/playlist?list=PLwjBY07V76p5mWNgdINjIiuUiItIeLhIN) |
+
+We are looking forward to seeing you there.
+
 ### Finding your interest
 
 To get started, it's important you find out which parts of Flux you are interested in first.
@@ -46,19 +63,6 @@ There currently are:
 
 All projects and teams are open to contributors and every part of the Flux project appreciates your help and consideration.
 Check out the links above to learn more about the team in question.
-
-### Meetings
-
-We run regular meetings and discuss things there.
-We are very happy if new users, contributors and developers join and we can put names to faces.
-
-All meetings can be found on our calendar: <https://lists.cncf.io/g/cncf-flux-dev/calendar>
-
-| Which | Times | Agenda & Minutes | Recordings |
-| ----- | ----- | ---------------- | ---------- |
-| Flux Dev Meetings | "early" meeting: Uneven weeks: Wed, 12:00 UTC, "late" meeting: Even weeks: Thu, 15:00 UTC | [Document](https://docs.google.com/document/d/167SKpaDUrpiBqNR2lXnQjXyb5Gxq6uB-Fujz7eBQxyw/edit) | [YouTube](https://www.youtube.com/playlist?list=PLwjBY07V76p5mWNgdINjIiuUiItIeLhIN) |
-
-We are looking forward to seeing you there.
 
 #### Subscribing to the Flux calendar
 


### PR DESCRIPTION
This file on the main branch here winds up rendered in the website as COMMUNITY.md thanks to external-sources configuration.

It should be possible to get a deploy preview to use the add-calendar-table branch temporarily?

The changes can be reviewed now, I should take one more pass at copy editing but someone else could also do it.

I've also added the Flux Bug Scrub to the Recurring Events table here. I think we should keep the Schedule table because it mentions the time zone that events are scheduled in, which isn't done anywhere else.

This is important for attendees to be aware of basically only when DST changes occur (since you may be in Europe and DST in US time changes versus your home time zone happen about a week apart, or vice versa.)

I could be convinced to remove it if we can somehow make the "subscribe" callout way more prominent, because most people are not subscribing to the Flux calendar. Also may be this schedule section is just no longer necessary, because we actually solved it with the Javascript time localization. (I do want to encourage more community members to host scheduled meetings though, and since this callout section draws attention to them specially, I would fight to keep it.)