### PR TITLE
Correct wrong maintainer email

### DIFF
--- a/CORE-MAINTAINERS
+++ b/CORE-MAINTAINERS
@@ -13,7 +13,7 @@ should.
 In alphabetical order:
 
 Aurel Canciu, NexHealth <aurel.canciu@nexhealth.com> (github: @relu, slack: relu)
-Hidde Beydals, Independent <hidde@hhh.computers> (github: @hiddeco, slack: hidde)
+Hidde Beydals, Independent <hidde@hhh.computer> (github: @hiddeco, slack: hidde)
 Max Jonas Werner, Associmates <max.werner@associmates.eu> (github: @makkes, slack: max)
 Paulo Gomes, SUSE <pjbgf@linux.com> (github: @pjbgf, slack: pjbgf)
 Sanskar Jaiswal, Independent <jaiswalsanskar078@gmail.com> (github: @aryan9600, slack: aryan9600)


### PR DESCRIPTION
Turns out it was incorrectly set up here in `CORE-MAINTAINERS` in the first place, I am sorry for the back and forth

Ref: fluxcd/website#2036 fluxcd/website#2037 #405 #384 

There is no `.computers` tld