### PR TITLE
Fix Project Membership data automation

### DIFF
--- a/.github/workflows/update-project-data.yaml
+++ b/.github/workflows/update-project-data.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip' # caching pip dependencies
-      - run: pip install -r ./project/requirements.txt
+      - run: pip3.10 install -r ./project/requirements.txt
       - run: |
           ./project/bin/get_maintainer_data
         env:


### PR DESCRIPTION
Tested at https://github.com/kingdonb/community/actions/runs/12432743481/job/34712822704 (the workflow still fails, but it gets past the dependency issue)

I guessed this was the issue when I tried running "pip install" on my local Mac environment, like the workflow does, and it failed. Running instead "pip3.10" to match the selected python version succeeded locally and seems to have succeeded as well in a GitHub Actions test on my fork.

I think this will fix it 🤞