### PR TITLE
Try disabling pip cache

### DIFF
--- a/.github/workflows/update-project-data.yaml
+++ b/.github/workflows/update-project-data.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-          cache: 'pip' # caching pip dependencies
+          # cache: 'pip' # caching pip dependencies
       - run: pip3.10 install -r ./project/requirements.txt
       - run: |
           ./project/bin/get_maintainer_data


### PR DESCRIPTION
It is very weird that I cannot reproduce this failure in https://github.com/kingdonb/community/actions

I should have verified that I could actually repro it, before assuming that I fixed it with #424 

I am going to (at least temporarily) disable the cache because a cache failure is the only thing I can think of which wouldn't reproduce on another repo fork.

Other possibilities I have considered:
* adding `python3.10` to the script shabang
* changing the dependency name from `ruamel.yaml` to `ruamel_yaml` which seems to be commonly used in StackOverflow replies to this issue

Upgrading to Python 3.11 might have also fixed this if it was a cache issue, all of those things we can try in a next PR, but if it was some strange cache failure I want to know 🤞 