### PR TITLE
Upgrade automation to Python 3.11

### DIFF
--- a/.github/workflows/update-project-data.yaml
+++ b/.github/workflows/update-project-data.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   updateProjectData:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,10 +22,10 @@ jobs:
       - run: |
           ./project/bin/get_maintainer_data
         env:
-          GITHUB_TOKEN: ${{secrets.BOT_GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
           title: Update maintainer data
           signoff: true
-          token: ${{secrets.BOT_GITHUB_TOKEN}}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-project-data.yaml
+++ b/.github/workflows/update-project-data.yaml
@@ -14,9 +14,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
-          # cache: 'pip' # caching pip dependencies
-      - run: python3.10 -m pip install -r ./project/requirements.txt
+          python-version: '3.11'
+          cache: 'pip' # caching pip dependencies
+      - run: python3.11 -m pip install -r ./project/requirements.txt
       - run: |
           ./project/bin/get_maintainer_data
         env:

--- a/project/requirements.txt
+++ b/project/requirements.txt
@@ -1,1 +1,1 @@
-ruamel.yaml
+ruamel_yaml


### PR DESCRIPTION
Not sure why we have BOT_GITHUB_TOKEN here, we could replace it with `GITHUB_TOKEN` which is automatically included and request the permission through the workflow?

I did actually test this end-to-end before I submitted:
* https://github.com/fluxcd/community/pull/426

and so I really *did* expect that to work!

Squashed and rebased my iteration from the other repo here, in case there was something important I did not include.

There is also an upgrade to Python 3.11 here, and #427 (which I will again rebase out of this one, so it can be merged separately)