### PR TITLE
Add @stealthybox to core maintainers

### DIFF
--- a/CORE-MAINTAINERS
+++ b/CORE-MAINTAINERS
@@ -14,6 +14,7 @@ In alphabetical order:
 
 Aurel Canciu, NexHealth <aurel.canciu@nexhealth.com> (github: @relu, slack: relu)
 Hidde Beydals, Independent <hidde@hhh.computer> (github: @hiddeco, slack: hidde)
+Leigh Capili, ControlPlane <capileigh@gmail.com> (github: @stealthybox, slack: Leigh Capili)
 Matheus Pimenta, ControlPlane <matheuscscp@linux.com> (github: @matheuscscp, slack: matheuscscp)
 Max Jonas Werner, Associmates <max.werner@associmates.eu> (github: @makkes, slack: max)
 Paulo Gomes, SUSE <pjbgf@linux.com> (github: @pjbgf, slack: pjbgf)

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -5,7 +5,6 @@ https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages
 In alphabetical order:
 
 Kingdon Barrett, Independent <kingdon@tuesdaystudios.com> (github: @kingdonb, slack: Kingdon B)
-Leigh Capili, Flox <capileigh@gmail.com> (github: @stealthybox, slack: Leigh Capili)
 Scott Rigby, Independent <scott@r6by.com> (github: @scottrigby, slack: scottrigby)
 Stefan Prodan, ControlPlane <stefan.prodan@gmail.com> (github: @stefanprodan, slack: stefanprodan)
 Tamao Nakahara, Independent <tamaonakahara@gmail.com> (github: @mewzherder, slack: tamao)


### PR DESCRIPTION
I'll be opening branches on the controller repos more frequently and working on docs.

membership #234 #417

process doc https://github.com/fluxcd/community/blob/main/PROCESS.md#applying-for-flux-maintainership

- mention all maintainers: @relu @hiddeco @matheuscscp @makkes @pjbgf @aryan9600 @souleb @stefanprodan
- Have maintainers submit their vote by +1. This is a unanimous vote and needs a 2/3 majority by core maintainers,