### PR TITLE
Retry links that cached error status, accept (but don't cache) 429

### DIFF
--- a/.github/workflows/lychee-cron.yaml
+++ b/.github/workflows/lychee-cron.yaml
@@ -25,8 +25,8 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2.4.1
         with:
-          # args: --cache --max-cache-age 1d --verbose --no-progress .
-          args: --accept '100..=103,200..=299,429' --cache --max-cache-age 1d --verbose --no-progress .
+          args: --cache --max-cache-age 1d --verbose --no-progress .
+          # args: --accept '100..=103,200..=299,429' --cache --max-cache-age 1d --verbose --no-progress .
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/lychee-cron.yaml
+++ b/.github/workflows/lychee-cron.yaml
@@ -25,8 +25,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2.4.1
         with:
-          args: --cache-exclude-status '429, 500..502' --cache --max-cache-age 1d --verbose --no-progress .
-          # args: --accept '100..=103,200..=299,429' --cache --max-cache-age 1d --verbose --no-progress .
+          args: --accept '100..=103,200..=299,429' --cache-exclude-status '429, 500..502' --cache --max-cache-age 1d --verbose --no-progress .
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/lychee-cron.yaml
+++ b/.github/workflows/lychee-cron.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2.4.1
         with:
-          args: --cache-exclude-status 429,500.. --cache --max-cache-age 1d --verbose --no-progress .
+          args: --cache-exclude-status '429, 500..' --cache --max-cache-age 1d --verbose --no-progress .
           # args: --accept '100..=103,200..=299,429' --cache --max-cache-age 1d --verbose --no-progress .
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/lychee-cron.yaml
+++ b/.github/workflows/lychee-cron.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2.4.1
         with:
-          args: --cache-exclude-status '429, 500..' --cache --max-cache-age 1d --verbose --no-progress .
+          args: --cache-exclude-status '429, 500..502' --cache --max-cache-age 1d --verbose --no-progress .
           # args: --accept '100..=103,200..=299,429' --cache --max-cache-age 1d --verbose --no-progress .
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/lychee-cron.yaml
+++ b/.github/workflows/lychee-cron.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2.4.1
         with:
-          args: --cache --max-cache-age 1d --verbose --no-progress .
+          args: --cache-exclude-status 429,500.. --cache --max-cache-age 1d --verbose --no-progress .
           # args: --accept '100..=103,200..=299,429' --cache --max-cache-age 1d --verbose --no-progress .
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/lychee-pr.yaml
+++ b/.github/workflows/lychee-pr.yaml
@@ -18,7 +18,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2.4.1
         with:
-          args: --cache-exclude-status 429,500.. --cache --max-cache-age 1d --verbose --no-progress .
+          args: --cache-exclude-status '429, 500..' --cache --max-cache-age 1d --verbose --no-progress .
           # args: --accept '100..=103,200..=299,429' --cache --max-cache-age 1d --verbose --no-progress .
           fail: true
         env:

--- a/.github/workflows/lychee-pr.yaml
+++ b/.github/workflows/lychee-pr.yaml
@@ -18,7 +18,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2.4.1
         with:
-          args: --cache-exclude-status '429, 500..' --cache --max-cache-age 1d --verbose --no-progress .
+          args: --cache-exclude-status '429, 500..502' --cache --max-cache-age 1d --verbose --no-progress .
           # args: --accept '100..=103,200..=299,429' --cache --max-cache-age 1d --verbose --no-progress .
           fail: true
         env:

--- a/.github/workflows/lychee-pr.yaml
+++ b/.github/workflows/lychee-pr.yaml
@@ -18,8 +18,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2.4.1
         with:
-          args: --cache-exclude-status '429, 500..502' --cache --max-cache-age 1d --verbose --no-progress .
-          # args: --accept '100..=103,200..=299,429' --cache --max-cache-age 1d --verbose --no-progress .
+          args: --accept '100..=103,200..=299,429' --cache-exclude-status '429, 500..502' --cache --max-cache-age 1d --verbose --no-progress .
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/lychee-pr.yaml
+++ b/.github/workflows/lychee-pr.yaml
@@ -18,7 +18,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2.4.1
         with:
-          args: --cache --max-cache-age 1d --verbose --no-progress .
+          args: --cache-exclude-status 429,500.. --cache --max-cache-age 1d --verbose --no-progress .
           # args: --accept '100..=103,200..=299,429' --cache --max-cache-age 1d --verbose --no-progress .
           fail: true
         env:

--- a/.github/workflows/lychee-pr.yaml
+++ b/.github/workflows/lychee-pr.yaml
@@ -18,8 +18,8 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2.4.1
         with:
-          # args: --cache --max-cache-age 1d --verbose --no-progress .
-          args: --accept '100..=103,200..=299,429' --cache --max-cache-age 1d --verbose --no-progress .
+          args: --cache --max-cache-age 1d --verbose --no-progress .
+          # args: --accept '100..=103,200..=299,429' --cache --max-cache-age 1d --verbose --no-progress .
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -110,9 +110,9 @@ For these kinds of decisions, a deadline can be given, and unanimity with a quor
 
 Links to relevant CNCF documentation:
 
-- <https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy>
-- <https://github.com/cncf/foundation/blob/master/policies-guidance/allowed-third-party-license-policy.md#approved-licenses-for-allowlist>
-- <https://github.com/cncf/foundation/blob/master/copyright-notices.md#copyright-notices>
+- <https://github.com/cncf/foundation/blob/main/charter.md#11-ip-policy>
+- <https://github.com/cncf/foundation/blob/main/policies-guidance/allowed-third-party-license-policy.md#approved-licenses-for-allowlist>
+- <https://github.com/cncf/foundation/blob/main/copyright-notices.md#copyright-notices>
 
 <!-- md links -->
 [Maintainer]: community-roles.md#maintainer

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -111,7 +111,7 @@ For these kinds of decisions, a deadline can be given, and unanimity with a quor
 Links to relevant CNCF documentation:
 
 - <https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy>
-- <https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist>
+- <https://github.com/cncf/foundation/blob/master/policies-guidance/allowed-third-party-license-policy.md#approved-licenses-for-allowlist>
 - <https://github.com/cncf/foundation/blob/master/copyright-notices.md#copyright-notices>
 
 <!-- md links -->


### PR DESCRIPTION
(This pull request actually begins in
* https://github.com/fluxcd/community/pull/437
which fixed the build)

Turns out when you cache error codes, they aren't retried automatically without options - that is slightly less than optimal!

So, you have to let the cache know which error states should be discarded and retried, I think this is the best compromise. I updated this PR based on what I found experimenting with the cache. Maybe we can merge this, or leave it sit until there is another problem.

---

I removed the `--accept [...]429` but I wasn't able to get this stuff to work:

https://github.com/lycheeverse/lychee-action?tab=readme-ov-file#utilising-the-cache-feature
(the stuff at the bottom, about always saving - `actions/cache/save@v4` always tells me that no key was specified, even when the restore-cache step succeeds. Not sure why, but it might have something to do with the cache key never having been populated from `main` before.)