### PR TITLE
Fix broken policy guidance link in GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -110,9 +110,9 @@ For these kinds of decisions, a deadline can be given, and unanimity with a quor
 
 Links to relevant CNCF documentation:
 
-- <https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy>
-- <https://github.com/cncf/foundation/blob/master/policies-guidance/allowed-third-party-license-policy.md#approved-licenses-for-allowlist>
-- <https://github.com/cncf/foundation/blob/master/copyright-notices.md#copyright-notices>
+- <https://github.com/cncf/foundation/blob/main/charter.md#11-ip-policy>
+- <https://github.com/cncf/foundation/blob/main/policies-guidance/allowed-third-party-license-policy.md#approved-licenses-for-allowlist>
+- <https://github.com/cncf/foundation/blob/main/copyright-notices.md#copyright-notices>
 
 <!-- md links -->
 [Maintainer]: community-roles.md#maintainer

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -111,7 +111,7 @@ For these kinds of decisions, a deadline can be given, and unanimity with a quor
 Links to relevant CNCF documentation:
 
 - <https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy>
-- <https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist>
+- <https://github.com/cncf/foundation/blob/master/policies-guidance/allowed-third-party-license-policy.md#approved-licenses-for-allowlist>
 - <https://github.com/cncf/foundation/blob/master/copyright-notices.md#copyright-notices>
 
 <!-- md links -->


### PR DESCRIPTION
The links job in website flagged an error here:

https://github.com/fluxcd/community/actions/runs/15510347506/job/43670487661#step:4:304

changed in:

* https://github.com/cncf/foundation/pull/1037