### PR TITLE
sched.co links are off-limits for checking

### DIFF
--- a/.github/workflows/lychee-cron.yaml
+++ b/.github/workflows/lychee-cron.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2.4.1
         with:
-          args: --accept '100..=103,200..=299,429' --cache-exclude-status '429, 500..502' --cache --max-cache-age 1d --verbose --no-progress .
+          args: --accept '100..=103,200..=299,429' --exclude '^https?://sched\.co/' --cache-exclude-status '429, 500..502' --cache --max-cache-age 1d --verbose --no-progress .
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/lychee-pr.yaml
+++ b/.github/workflows/lychee-pr.yaml
@@ -18,7 +18,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2.4.1
         with:
-          args: --accept '100..=103,200..=299,429' --cache-exclude-status '429, 500..502' --cache --max-cache-age 1d --verbose --no-progress .
+          args: --accept '100..=103,200..=299,429' --exclude '^https?://sched\.co/' --cache-exclude-status '429, 500..502' --cache --max-cache-age 1d --verbose --no-progress .
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
GitHub Actions running lychee and others apparently cause enough traffic to sched.co to warrant blocking, they were returning rate limiting errors for a while, but now they return 403: Network error: forbidden

https://github.com/fluxcd/community/actions/runs/16150856467/job/45581500176#step:4:285

I would assume this isn't going to be reversed, so let's stop checking (and hopefully return the lychee cron & pr checks to working order again)