### PR TITLE
Add @cappyzawa to project members

### DIFF
--- a/PROJECT-MEMBERS.md
+++ b/PROJECT-MEMBERS.md
@@ -15,3 +15,4 @@ who are not maintainers (yet).
 | Daniel Holbach  | @dholbach      | Daniel Holbach  | Independent  | PR #302     |
 | Luke Mallon     | @nalum         | nalum           | Independent  | Issue #339  |
 | Steve Wade      | @swade1987     | Steve Wade      | Independent  | Issue #390  |
+| Shu Kutsuzawa   | @cappyzawa     | cappyzawa       | Independent  | Issue #450  |


### PR DESCRIPTION
Following the membership process described in PROCESS.md after receiving sponsor approvals in #450.

@fluxcd/core-maintainers 🙏