### PR TITLE
Make iCal link more prominent

### DIFF
--- a/.github/workflows/lychee-cron.yaml
+++ b/.github/workflows/lychee-cron.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2.4.1
         with:
-          args: --accept '100..=103,200..=299,429' --exclude '^https?://sched\.co/' --cache-exclude-status '429, 500..502' --cache --max-cache-age 1d --verbose --no-progress .
+          args: --accept '100..=103,200..=299,429' --exclude '^https?://sched\.co/' --exclude '^https?://.+sched\.com?/' --exclude '^https?://.+wikia.com/' --cache-exclude-status '429, 500..502' --cache --max-cache-age 1d --verbose --no-progress .
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/lychee-pr.yaml
+++ b/.github/workflows/lychee-pr.yaml
@@ -18,7 +18,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2.4.1
         with:
-          args: --accept '100..=103,200..=299,429' --exclude '^https?://sched\.co/' --cache-exclude-status '429, 500..502' --cache --max-cache-age 1d --verbose --no-progress .
+          args: --accept '100..=103,200..=299,429' --exclude '^https?://sched\.co/' --exclude '^https?://.+sched\.com?/' --exclude '^https?://.+wikia.com/' --cache-exclude-status '429, 500..502' --cache --max-cache-age 1d --verbose --no-progress .
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ The upcoming meetings, talks, and community events for the next month are here:
 
 {{< home/calendar >}}
 
-Our calendar data is hosted on LFX Platform, which has the option to subscribe via iCal Link: <https://zoom-lfx.platform.linuxfoundation.org/meetings/fluxcd>
+Our calendar data is publicly available at: <https://zoom-lfx.platform.linuxfoundation.org/meetings/fluxcd>
+
+The LFX Platform calendar has the option to subscribe to Flux events via iCal Link. You can subscribe directly to the iCal feed via the link below:
+
+```
+https://webcal.prod.itx.linuxfoundation.org/lfx/a092M00001IfTjDQAV
+```
 
 We are very happy if new users, contributors and developers join and we can put names to faces!
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ Our calendar data is publicly available at: <https://zoom-lfx.platform.linuxfoun
 
 The LFX Platform calendar has the option to subscribe to Flux events via iCal Link. You can subscribe directly to the iCal feed via the link below:
 
-```
-https://webcal.prod.itx.linuxfoundation.org/lfx/a092M00001IfTjDQAV
-```
+<https://webcal.prod.itx.linuxfoundation.org/lfx/a092M00001IfTjDQAV>
 
 We are very happy if new users, contributors and developers join and we can put names to faces!
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,1 +1,1 @@
-This document was moved to <https://github.com/fluxcd/website/blob/main/content/en/support.md>.
+This document was moved to <https://github.com/fluxcd/.github/blob/main/SUPPORT.md>.


### PR DESCRIPTION
Closes #476 

We have uncovered today that the LFX Platform calendar is truly public, and the .ics link can be shared without worry that it represents some personalized calendar data.

Feedback from the community said that it was too difficult to find the iCal link on the public Linux Foundation calendar page, when coming from the Flux Community website:

* https://fluxcd.io/community/

links to:

* https://zoom-lfx.platform.linuxfoundation.org/meetings/fluxcd?view=week

which has:

<img width="1222" height="500" alt="Screenshot 2026-08-12 at 8 50 04 AM" src="https://github.com/user-attachments/assets/4478fe5a-ec4c-4ddc-9279-cb4568327cc5" />

...but since that data must be static, because by nature people will only need to subscribe to the ical feed once - we can share it directly on the Community page. It's not likely or possible that it's ever going to change or rotate in the platform.

I also added a note to the README in `<!-- HTML comments -->` that should not make it to the website, but is intended to help folks who find their way in via https://github.com/fluxcd/community/#getting-involved - since there, it just shows as:

<img width="883" height="246" alt="Screenshot 2026-08-12 at 8 53 13 AM" src="https://github.com/user-attachments/assets/1db87809-cb2f-43cd-97c5-77fa847c721e" />

Not sure how this will turn out, so I am marking it as draft for review.